### PR TITLE
fix(hub): add aria-labels to social feed action buttons (#66)

### DIFF
--- a/js/hub/social-feed.js
+++ b/js/hub/social-feed.js
@@ -1230,18 +1230,18 @@ const SocialFeed = {
             '</div>' +
             '<div class="social-card-footer">' +
                 (viewCount > 0 ? '<span class="sf-views"><i class="far fa-eye"></i> ' + viewCount + '</span>' : '') +
-                '<button class="engagement-btn like-btn' + (event.is_liked ? ' liked' : '') + '" data-id="' + this.escapeHtml(String(event.id)) + '" title="Me gusta">' +
+                '<button class="engagement-btn like-btn' + (event.is_liked ? ' liked' : '') + '" data-id="' + this.escapeHtml(String(event.id)) + '" aria-label="Me gusta" title="Me gusta">' +
                     '<i class="' + (event.is_liked ? 'fas' : 'far') + ' fa-heart"></i>' +
                     '<span>' + likesText + '</span>' +
                 '</button>' +
-                '<button class="engagement-btn comment-btn" data-id="' + this.escapeHtml(String(event.id)) + '" title="Comentar">' +
+                '<button class="engagement-btn comment-btn" data-id="' + this.escapeHtml(String(event.id)) + '" aria-label="Comentar" title="Comentar">' +
                     '<i class="far fa-comment"></i>' +
                     '<span>' + commentsText + '</span>' +
                 '</button>' +
-                '<button class="engagement-btn share-btn" data-id="' + this.escapeHtml(String(event.id)) + '" title="Compartir">' +
+                '<button class="engagement-btn share-btn" data-id="' + this.escapeHtml(String(event.id)) + '" aria-label="Compartir" title="Compartir">' +
                     '<i class="fas fa-share-alt"></i>' +
                 '</button>' +
-                '<button class="engagement-btn bookmark-btn' + (event.is_bookmarked ? ' bookmarked' : '') + '" data-id="' + this.escapeHtml(String(event.id)) + '" title="Guardar">' +
+                '<button class="engagement-btn bookmark-btn' + (event.is_bookmarked ? ' bookmarked' : '') + '" data-id="' + this.escapeHtml(String(event.id)) + '" aria-label="Guardar" title="Guardar">' +
                     '<i class="' + (event.is_bookmarked ? 'fas' : 'far') + ' fa-bookmark"></i>' +
                 '</button>' +
             '</div>' +


### PR DESCRIPTION
## Summary

Add accessibility aria-label attributes to social feed action buttons (like, comment, share, bookmark) in js/hub/social-feed.js for screen reader support.

## Changes

- Like button → aria-label="Me gusta"
- Comment button → aria-label="Comentar"  
- Share button → aria-label="Compartir"
- Bookmark button → aria-label="Guardar"

## Bounty

This PR resolves issue #66 which has a **25 LTD bounty** reward.

---
- [x] I have read and followed the CONTRIBUTING.md guidelines
- [x] This PR only changes the specified file(s)
- [x] All 4 action buttons now have aria-label in Spanish (es-HN)
- [x] No other code changed