### PR TITLE
feat: add dark/light theme toggle with localStorage persistence

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -1,7 +1,8 @@
 <!-- ============================================
      LA TANDA - HEADER GLOBAL COMPONENT
-     Version: 1.3 - Added wallet dropdown panel
+     Version: 1.4 - Added theme toggle
      ============================================ -->
+<script src="components/theme-toggle.js"></script>
 <header class="lt-header" id="mainHeader">
     <div class="lt-header-container">
         <!-- Left: Menu + Brand -->
@@ -76,6 +77,9 @@
 
         <!-- Right: Actions -->
         <div class="lt-header-right">
+            <button class="lt-header-btn" id="themeToggle" aria-label="Cambiar tema" title="Cambiar a modo claro/oscuro">
+                <i class="fas fa-moon" id="themeIcon"></i>
+            </button>
             <button class="lt-header-btn" id="notificationsBtn" aria-label="Notificaciones">
                 <i class="fas fa-bell"></i>
                 <span class="lt-badge" id="notifBadge"></span>

--- a/components/theme-toggle.js
+++ b/components/theme-toggle.js
@@ -1,0 +1,63 @@
+/**
+ * Theme Toggle Module
+ * Handles dark/light theme switching with localStorage persistence
+ */
+
+const ThemeToggle = {
+    THEME_KEY: 'la-tanda-theme',
+    
+    init() {
+        // Apply theme early before render to prevent flash
+        this.applyStoredTheme();
+        
+        // Listen for toggle button
+        const toggleBtn = document.getElementById('themeToggle');
+        if (toggleBtn) {
+            toggleBtn.addEventListener('click', () => this.toggle());
+        }
+        
+        // Listen for system preference changes
+        window.matchMedia('(prefers-color-scheme: light)').addEventListener('change', (e) => {
+            if (!localStorage.getItem(this.THEME_KEY)) {
+                this.setTheme(e.matches ? 'light' : 'dark');
+            }
+        });
+    },
+    
+    getSystemPreference() {
+        return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+    },
+    
+    applyStoredTheme() {
+        const stored = localStorage.getItem(this.THEME_KEY);
+        const theme = stored || this.getSystemPreference();
+        this.setTheme(theme, false);
+    },
+    
+    setTheme(theme, persist = true) {
+        document.documentElement.setAttribute('data-theme', theme);
+        
+        // Update icon
+        const icon = document.getElementById('themeIcon');
+        if (icon) {
+            icon.className = theme === 'light' ? 'fas fa-sun' : 'fas fa-moon';
+        }
+        
+        if (persist) {
+            localStorage.setItem(this.THEME_KEY, theme);
+        }
+    },
+    
+    toggle() {
+        const current = document.documentElement.getAttribute('data-theme') || 'dark';
+        const next = current === 'dark' ? 'light' : 'dark';
+        this.setTheme(next);
+    }
+};
+
+// Auto-init when DOM ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => ThemeToggle.init());
+} else {
+    ThemeToggle.init();
+}

--- a/home-dashboard.html
+++ b/home-dashboard.html
@@ -10,6 +10,14 @@
     <link rel="preload" href="/js/hub/social-feed.js?v=12.1" as="script">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#0f172a">
+    <script>
+        // Apply theme before render to prevent flash
+        (function() {
+            var theme = localStorage.getItem('la-tanda-theme') || 
+                (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
     <title data-i18n="dashboard.page_title">La Tanda - Web3 DeFi Ecosystem</title>
     
     <!-- Open Graph / Facebook -->
@@ -280,7 +288,7 @@
         }
 
         :root {
-            /* La Tanda Web3 Colors */
+            /* La Tanda Web3 Colors - Dark Theme (default) */
             --tanda-cyan: #00FFFF;
             --tanda-cyan-light: #7FFFD8;
             --tanda-cyan-dark: #00E5E5;
@@ -297,6 +305,25 @@
             --success-color: #22d55e;
             --warning-color: #fbbf24;
             --error-color: #f87171;
+        }
+        
+        [data-theme="light"] {
+            --tanda-cyan: #0088aa;
+            --tanda-cyan-light: #00ccaa;
+            --tanda-cyan-dark: #006688;
+            --tanda-black: #1a1a1a;
+            --text-primary: #1a1a2e;
+            --text-secondary: rgba(26, 26, 46, 0.7);
+            --text-accent: #0088aa;
+            --bg-primary: #f8fafc;
+            --bg-secondary: #e2e8f0;
+            --bg-card: rgba(255, 255, 255, 0.95);
+            --border-card: rgba(0, 136, 170, 0.15);
+            --border-accent: rgba(0, 136, 170, 0.3);
+            --crypto-gold: #d4a500;
+            --success-color: #22c55e;
+            --warning-color: #f59e0b;
+            --error-color: #ef4444;
         }
         
         * {


### PR DESCRIPTION
## Problem

The platform currently uses a dark theme exclusively. Many users prefer light mode, especially during daytime use.

## Solution

Add a dark/light theme toggle with the following features:

- Toggle button in the header (moon/sun icon)
- Light theme CSS variables that override dark defaults
- Theme applied early in `<head>` to prevent flash of wrong theme on page load
- Respects `prefers-color-scheme` media query on first visit (no stored preference)
- Persists user preference in localStorage

## Changes

- `components/header.html`: Added theme toggle button
- `components/theme-toggle.js`: New theme toggle module
- `home-dashboard.html`: Added light theme CSS variables and early theme application script

## Testing

- [x] Toggle switches between dark and light themes
- [x] Preference persists across sessions
- [x] Respects system preference on first visit
- [x] No flash of wrong theme on page load

Fixes #84