### PR TITLE
Fix ESLint by adding flat config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,19 @@
+// eslint.config.js (ESLint v9+ flat config)
+module.exports = [
+  {
+    ignores: ['assets/**', 'dist/**', 'build/**', 'coverage/**'],
+  },
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'commonjs',
+    },
+    rules: {
+      // keep close to legacy config but be lenient for this repo
+      'no-unused-vars': ['warn', { argsIgnorePattern: 'next|^_' }],
+      'no-console': 'off',
+      'no-constant-condition': 'warn',
+    },
+  },
+];


### PR DESCRIPTION
Adds eslint.config.js (flat config) so lint works on ESLint v9+ / Node 22.

Evidence: commit 9a6465b