### PR TITLE
feat: Chain Explorer search + route-based detail pages (#89)

### DIFF
--- a/chain/index.html
+++ b/chain/index.html
@@ -913,6 +913,225 @@
             word-break: break-all;
         }
 
+        /* Explorer search + detail */
+        .explorer-search-wrap {
+            padding: 1rem 1.25rem 0.6rem;
+        }
+
+        .explorer-search-form {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .explorer-search-type,
+        .explorer-search-input {
+            background: var(--surface2);
+            border: 1px solid var(--border);
+            color: var(--text);
+            border-radius: 8px;
+            padding: 0.65rem 0.8rem;
+            font-size: 0.84rem;
+            font-family: var(--font-body);
+            min-height: 40px;
+        }
+
+        .explorer-search-type {
+            min-width: 155px;
+            cursor: pointer;
+        }
+
+        .explorer-search-input {
+            flex: 1;
+            min-width: 260px;
+            font-family: var(--font-mono);
+        }
+
+        .explorer-search-input:focus,
+        .explorer-search-type:focus {
+            outline: none;
+            border-color: var(--border-bright);
+            box-shadow: 0 0 0 3px var(--cyan-glow2);
+        }
+
+        .explorer-search-btn {
+            background: linear-gradient(135deg, var(--cyan), #06b6d4);
+            color: var(--bg);
+            border: none;
+            border-radius: 8px;
+            padding: 0.68rem 1rem;
+            min-height: 40px;
+            font-size: 0.84rem;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+
+        .explorer-search-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 4px 16px rgba(0, 255, 255, 0.25);
+        }
+
+        .explorer-search-hint {
+            margin-top: 0.65rem;
+            color: var(--text-dim);
+            font-size: 0.75rem;
+            line-height: 1.45;
+        }
+
+        .explorer-search-hint code {
+            background: rgba(0, 0, 0, 0.22);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 4px;
+            padding: 0.05rem 0.32rem;
+            color: #a5f3fc;
+        }
+
+        .explorer-detail {
+            padding: 0.35rem 1.25rem 1.25rem;
+        }
+
+        .detail-card {
+            background: var(--surface2);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 10px;
+            padding: 1rem;
+            margin-top: 0.72rem;
+        }
+
+        .detail-header {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            gap: 0.75rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .detail-title {
+            font-size: 1rem;
+            font-weight: 700;
+            color: var(--text);
+            line-height: 1.3;
+        }
+
+        .detail-subtitle {
+            color: var(--text-dim);
+            font-size: 0.78rem;
+            margin-top: 0.2rem;
+            font-family: var(--font-mono);
+            word-break: break-all;
+        }
+
+        .detail-pill {
+            display: inline-flex;
+            align-items: center;
+            border-radius: 999px;
+            font-size: 0.72rem;
+            font-weight: 700;
+            padding: 0.25rem 0.58rem;
+            white-space: nowrap;
+        }
+
+        .detail-pill.ok {
+            color: var(--green);
+            background: var(--green-dim);
+        }
+
+        .detail-pill.warn {
+            color: var(--amber);
+            background: var(--amber-dim);
+        }
+
+        .detail-pill.err {
+            color: var(--red);
+            background: rgba(239, 68, 68, 0.16);
+        }
+
+        .detail-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.62rem;
+        }
+
+        .detail-item {
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 8px;
+            padding: 0.62rem 0.75rem;
+            background: rgba(0, 0, 0, 0.16);
+        }
+
+        .detail-key {
+            color: var(--text-dim);
+            font-size: 0.72rem;
+            margin-bottom: 0.22rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        .detail-value {
+            font-family: var(--font-mono);
+            font-size: 0.82rem;
+            word-break: break-word;
+            line-height: 1.4;
+        }
+
+        .detail-section-title {
+            font-size: 0.82rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-dim);
+            margin: 1rem 0 0.55rem;
+        }
+
+        .detail-table-wrap {
+            overflow-x: auto;
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 9px;
+        }
+
+        .detail-table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 680px;
+        }
+
+        .detail-table th {
+            text-align: left;
+            padding: 0.55rem 0.72rem;
+            font-size: 0.7rem;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            color: var(--text-dim);
+            background: rgba(0, 0, 0, 0.18);
+        }
+
+        .detail-table td {
+            padding: 0.58rem 0.72rem;
+            font-size: 0.78rem;
+            border-top: 1px solid rgba(255, 255, 255, 0.06);
+            vertical-align: top;
+            line-height: 1.4;
+            word-break: break-word;
+        }
+
+        .detail-table .mono {
+            font-family: var(--font-mono);
+            font-size: 0.74rem;
+        }
+
+        .route-link {
+            color: var(--cyan);
+            text-decoration: none;
+            font-family: var(--font-mono);
+            font-size: 0.76rem;
+        }
+
+        .route-link:hover {
+            text-decoration: underline;
+        }
+
         /* ============================================================
            8. RESOURCES
            ============================================================ */
@@ -1225,6 +1444,14 @@
 
             .network-grid { grid-template-columns: 1fr; }
 
+            .explorer-search-form { flex-direction: column; }
+            .explorer-search-type,
+            .explorer-search-input,
+            .explorer-search-btn { width: 100%; min-width: 0; }
+            .detail-grid { grid-template-columns: 1fr; }
+            .detail-header { flex-direction: column; align-items: flex-start; }
+            .detail-table { min-width: 560px; }
+
             .blocks-table th:nth-child(3),
             .blocks-table td:nth-child(3) { display: none; }
 
@@ -1245,6 +1472,7 @@
             .stat-value { font-size: 1.35rem; }
             .resources-grid { grid-template-columns: repeat(2, 1fr); }
             .footer-links { flex-wrap: wrap; gap: 1rem; justify-content: center; }
+            .detail-table { min-width: 420px; }
         }
     </style>
 </head>
@@ -1622,6 +1850,40 @@
                 </p>
             </div>
 
+            <!-- Search + Detail -->
+            <div class="explorer-subsection fade-up">
+                <div class="explorer-header">
+                    <h3><i class="fas fa-magnifying-glass" style="color:var(--cyan);margin-right:0.5rem"></i>Busqueda y Detalle</h3>
+                    <span class="hint">Rutas: #tx / #address / #validator</span>
+                </div>
+                <div class="explorer-search-wrap">
+                    <form class="explorer-search-form" id="explorerSearchForm">
+                        <select class="explorer-search-type" id="explorerSearchType" aria-label="Tipo de busqueda">
+                            <option value="tx">Transaccion</option>
+                            <option value="address">Direccion</option>
+                            <option value="validator">Validador</option>
+                        </select>
+                        <input
+                            class="explorer-search-input"
+                            type="text"
+                            id="explorerSearchInput"
+                            placeholder="Pega hash, direccion o valoper..."
+                            autocomplete="off"
+                            spellcheck="false"
+                            aria-label="Buscar en explorer">
+                        <button type="submit" class="explorer-search-btn">
+                            <i class="fas fa-search"></i> Buscar
+                        </button>
+                    </form>
+                    <div class="explorer-search-hint">
+                        Ejemplos: <code>#tx/ABCD...</code> <code>#address/ltd1...</code> <code>#validator/ltdvaloper1...</code>
+                    </div>
+                </div>
+                <div class="explorer-detail" id="explorerDetail">
+                    <div class="loading">Busca una transaccion, direccion o validador para ver detalles.</div>
+                </div>
+            </div>
+
             <!-- Recent Blocks -->
             <div class="explorer-subsection fade-up">
                 <div class="explorer-header">
@@ -1823,6 +2085,9 @@
 
         let recentBlocks = [];
         let lastBlockHeight = 0;
+        let latestValidators = [];
+        let rpcValidatorsCache = { at: 0, data: [] };
+        let explorerRouteToken = 0;
 
         // ---- Helpers ----
         function fmt(n) {
@@ -1857,6 +2122,228 @@
             var r = await fetch(url);
             if (!r.ok) throw new Error(r.status);
             return r.json();
+        }
+
+        function formatTokenAmount(amount, denom) {
+            if (denom === 'ultd') return ultdToLtd(amount) + ' LTD';
+            var n = Number(amount);
+            var value = Number.isFinite(n) ? n.toLocaleString('en-US', { maximumFractionDigits: 6 }) : String(amount || '--');
+            return value + (denom ? ' ' + denom : '');
+        }
+
+        function formatCoin(coin) {
+            if (!coin || typeof coin !== 'object') return '--';
+            return formatTokenAmount(coin.amount, coin.denom);
+        }
+
+        function formatCoins(coins) {
+            if (!Array.isArray(coins) || coins.length === 0) return '--';
+            return coins.map(function(c) { return formatCoin(c); }).join(', ');
+        }
+
+        function looksLikeAddress(v) {
+            return typeof v === 'string' && /^ltd1[0-9a-z]+$/i.test(v);
+        }
+
+        function looksLikeValidatorAddress(v) {
+            return typeof v === 'string' && /^ltdvaloper1[0-9a-z]+$/i.test(v);
+        }
+
+        function looksLikeTxHash(v) {
+            return typeof v === 'string' && /^[a-f0-9]{32,128}$/i.test(v);
+        }
+
+        function routeHref(kind, value) {
+            return '#' + kind + '/' + encodeURIComponent(value);
+        }
+
+        function routeLink(value) {
+            if (!value) return '--';
+            if (looksLikeAddress(value)) {
+                return '<a class="route-link" href="' + routeHref('address', value) + '">' + escapeHtml(shortHash(value)) + '</a>';
+            }
+            if (looksLikeValidatorAddress(value)) {
+                return '<a class="route-link" href="' + routeHref('validator', value) + '">' + escapeHtml(shortHash(value)) + '</a>';
+            }
+            if (looksLikeTxHash(value)) {
+                return '<a class="route-link" href="' + routeHref('tx', value) + '">' + escapeHtml(shortHash(value)) + '</a>';
+            }
+            return '<span class="mono">' + escapeHtml(shortHash(String(value))) + '</span>';
+        }
+
+        function setExplorerDetailHtml(html) {
+            var target = document.getElementById('explorerDetail');
+            if (!target) return;
+            target.innerHTML = html;
+        }
+
+        function renderExplorerWelcome() {
+            setExplorerDetailHtml('<div class="loading">Busca una transaccion, direccion o validador para ver detalles.</div>');
+        }
+
+        function renderExplorerLoading(title, value) {
+            setExplorerDetailHtml(
+                '<div class="detail-card">' +
+                    '<div class="detail-header">' +
+                        '<div>' +
+                            '<div class="detail-title">' + escapeHtml(title) + '</div>' +
+                            '<div class="detail-subtitle">' + escapeHtml(value || '') + '</div>' +
+                        '</div>' +
+                        '<span class="detail-pill warn">Consultando...</span>' +
+                    '</div>' +
+                '</div>'
+            );
+        }
+
+        function renderExplorerError(message, value) {
+            setExplorerDetailHtml(
+                '<div class="error-msg">' + escapeHtml(message) + '</div>' +
+                (value ? '<div class="detail-card"><div class="detail-key">Lookup</div><div class="detail-value">' + escapeHtml(value) + '</div></div>' : '')
+            );
+        }
+
+        function parseExplorerRoute() {
+            var hash = window.location.hash || '';
+            var raw = hash.charAt(0) === '#' ? hash.slice(1) : hash;
+            var split = raw.indexOf('/');
+            if (split < 1) return null;
+            var kind = raw.slice(0, split).toLowerCase();
+            if (kind !== 'tx' && kind !== 'address' && kind !== 'validator') return null;
+            var value = raw.slice(split + 1).trim();
+            if (!value) return null;
+            try {
+                value = decodeURIComponent(value);
+            } catch (_) {}
+            return { kind: kind, value: value };
+        }
+
+        function parseInputRoute(raw, fallbackType) {
+            var text = (raw || '').trim();
+            if (!text) return null;
+            var normalized = text.charAt(0) === '#' ? text.slice(1) : text;
+            var sep = normalized.indexOf('/');
+            if (sep > 0) {
+                var kind = normalized.slice(0, sep).toLowerCase();
+                var value = normalized.slice(sep + 1).trim();
+                if ((kind === 'tx' || kind === 'address' || kind === 'validator') && value) {
+                    return { kind: kind, value: value };
+                }
+            }
+            return { kind: fallbackType, value: text };
+        }
+
+        function operatorToDelegator(op) {
+            if (!looksLikeValidatorAddress(op)) return '';
+            return 'ltd' + op.slice('ltdvaloper'.length);
+        }
+
+        function extractByKeys(obj, keys) {
+            var i;
+            for (i = 0; i < keys.length; i += 1) {
+                if (obj && obj[keys[i]] !== undefined && obj[keys[i]] !== null && obj[keys[i]] !== '') {
+                    return String(obj[keys[i]]);
+                }
+            }
+            return '--';
+        }
+
+        function extractMsgAmount(msg) {
+            if (!msg || typeof msg !== 'object') return '--';
+            if (Array.isArray(msg.amount)) return formatCoins(msg.amount);
+            if (msg.amount && typeof msg.amount === 'object') return formatCoin(msg.amount);
+            if (msg.amount && typeof msg.amount === 'string') {
+                if (msg.denom) return formatTokenAmount(msg.amount, msg.denom);
+                return msg.amount;
+            }
+            if (msg.token && typeof msg.token === 'object') return formatCoin(msg.token);
+            if (msg.value && msg.denom) return formatTokenAmount(msg.value, msg.denom);
+            if (Array.isArray(msg.coins)) return formatCoins(msg.coins);
+            return '--';
+        }
+
+        function summarizeMessage(msg) {
+            return {
+                type: extractByKeys(msg, ['@type', 'type']),
+                sender: extractByKeys(msg, ['from_address', 'delegator_address', 'sender', 'creator', 'granter']),
+                receiver: extractByKeys(msg, ['to_address', 'validator_address', 'recipient', 'withdraw_address', 'payee']),
+                amount: extractMsgAmount(msg)
+            };
+        }
+
+        const BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+
+        function bech32Polymod(values) {
+            var generators = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+            var chk = 1;
+            values.forEach(function(v) {
+                var top = chk >> 25;
+                chk = ((chk & 0x1ffffff) << 5) ^ v;
+                for (var i = 0; i < 5; i += 1) {
+                    if ((top >> i) & 1) chk ^= generators[i];
+                }
+            });
+            return chk;
+        }
+
+        function bech32HrpExpand(hrp) {
+            var out = [];
+            for (var i = 0; i < hrp.length; i += 1) out.push(hrp.charCodeAt(i) >> 5);
+            out.push(0);
+            for (var j = 0; j < hrp.length; j += 1) out.push(hrp.charCodeAt(j) & 31);
+            return out;
+        }
+
+        function bech32Checksum(hrp, data) {
+            var values = bech32HrpExpand(hrp).concat(data).concat([0, 0, 0, 0, 0, 0]);
+            var mod = bech32Polymod(values) ^ 1;
+            var out = [];
+            for (var i = 0; i < 6; i += 1) out.push((mod >> (5 * (5 - i))) & 31);
+            return out;
+        }
+
+        function bech32Encode(hrp, data) {
+            var combined = data.concat(bech32Checksum(hrp, data));
+            var chars = combined.map(function(d) { return BECH32_CHARSET[d]; }).join('');
+            return hrp + '1' + chars;
+        }
+
+        function convertBits(data, fromBits, toBits, pad) {
+            var acc = 0;
+            var bits = 0;
+            var out = [];
+            var maxv = (1 << toBits) - 1;
+            data.forEach(function(value) {
+                acc = (acc << fromBits) | value;
+                bits += fromBits;
+                while (bits >= toBits) {
+                    bits -= toBits;
+                    out.push((acc >> bits) & maxv);
+                }
+            });
+            if (pad) {
+                if (bits > 0) out.push((acc << (toBits - bits)) & maxv);
+            } else if (bits >= fromBits || ((acc << (toBits - bits)) & maxv)) {
+                return null;
+            }
+            return out;
+        }
+
+        function hexToBytes(hex) {
+            var clean = (hex || '').toString().replace(/^0x/i, '');
+            if (!/^[0-9a-fA-F]+$/.test(clean) || clean.length % 2 !== 0) return null;
+            var bytes = [];
+            for (var i = 0; i < clean.length; i += 2) {
+                bytes.push(parseInt(clean.slice(i, i + 2), 16));
+            }
+            return bytes;
+        }
+
+        function hexToBech32(prefix, hex) {
+            var bytes = hexToBytes(hex);
+            if (!bytes) return '';
+            var words = convertBits(bytes, 8, 5, true);
+            if (!words) return '';
+            return bech32Encode(prefix, words);
         }
 
         // ---- Nav: scroll effect + active tracking ----
@@ -1922,6 +2409,361 @@
 
         document.querySelectorAll('.fade-up').forEach(function(el) {
             observer.observe(el);
+        });
+
+        // ---- Explorer routing + detail lookups ----
+        function setExplorerHash(kind, value) {
+            var nextHash = routeHref(kind, value);
+            if (window.location.hash === nextHash) {
+                handleExplorerRoute(true);
+                return;
+            }
+            window.location.hash = nextHash;
+        }
+
+        function friendlyLookupError(err, missingMsg, genericMsg) {
+            var code = err && err.message ? String(err.message) : '';
+            if (code === '404') return missingMsg;
+            if (code === '400') return 'Entrada invalida para esta consulta.';
+            return genericMsg;
+        }
+
+        async function getRpcValidators() {
+            if (Date.now() - rpcValidatorsCache.at < 120000 && rpcValidatorsCache.data.length > 0) {
+                return rpcValidatorsCache.data;
+            }
+            var data = await fetchJSON(RPC + '/validators?per_page=200');
+            rpcValidatorsCache = {
+                at: Date.now(),
+                data: (data.result && data.result.validators) ? data.result.validators : []
+            };
+            return rpcValidatorsCache.data;
+        }
+
+        async function fetchValidatorUptime(validator) {
+            try {
+                var targetKey = validator && validator.consensus_pubkey ? validator.consensus_pubkey.key : '';
+                if (!targetKey) return '--';
+
+                var rpcVals = await getRpcValidators();
+                var consHex = '';
+                rpcVals.forEach(function(v) {
+                    if (!consHex && v.pub_key && v.pub_key.value === targetKey) {
+                        consHex = v.address;
+                    }
+                });
+
+                if (!consHex) return '--';
+                var consAddr = hexToBech32('ltdvalcons', consHex);
+                if (!consAddr) return '--';
+
+                var data = await Promise.all([
+                    fetchJSON(REST + '/cosmos/slashing/v1beta1/signing_infos/' + encodeURIComponent(consAddr)),
+                    fetchJSON(REST + '/cosmos/slashing/v1beta1/params')
+                ]);
+
+                var info = data[0].val_signing_info || {};
+                var params = data[1].params || {};
+                var windowSize = Number(params.signed_blocks_window || 0);
+                var missed = Number(info.missed_blocks_counter || 0);
+                if (!Number.isFinite(windowSize) || windowSize <= 0) return '--';
+
+                var hit = Math.max(windowSize - missed, 0);
+                return ((hit / windowSize) * 100).toFixed(1) + '%';
+            } catch (_) {
+                return '--';
+            }
+        }
+
+        async function renderTxRoute(hash, token) {
+            var lookup = (hash || '').trim();
+            if (!lookup) {
+                renderExplorerError('Ingresa un hash de transaccion.', lookup);
+                return;
+            }
+
+            renderExplorerLoading('Transaccion', lookup);
+            try {
+                var data = await fetchJSON(REST + '/cosmos/tx/v1beta1/txs/' + encodeURIComponent(lookup));
+                if (token !== explorerRouteToken) return;
+
+                var tx = data.tx || {};
+                var txr = data.tx_response || {};
+                var code = Number(txr.code || 0);
+                var pillClass = code === 0 ? 'ok' : 'err';
+                var pillText = code === 0 ? 'Confirmada' : 'Fallida (code ' + code + ')';
+                var msgs = (tx.body && tx.body.messages) ? tx.body.messages : [];
+
+                var rows = msgs.length === 0
+                    ? '<tr><td colspan="5" class="loading">Esta transaccion no incluye mensajes decodificados.</td></tr>'
+                    : msgs.map(function(m, idx) {
+                        var summary = summarizeMessage(m);
+                        return '<tr>' +
+                            '<td class="mono">' + escapeHtml(String(idx + 1)) + '</td>' +
+                            '<td class="mono">' + escapeHtml(summary.type) + '</td>' +
+                            '<td>' + routeLink(summary.sender) + '</td>' +
+                            '<td>' + routeLink(summary.receiver) + '</td>' +
+                            '<td class="mono">' + escapeHtml(summary.amount) + '</td>' +
+                        '</tr>';
+                    }).join('');
+
+                setExplorerDetailHtml(
+                    '<div class="detail-card">' +
+                        '<div class="detail-header">' +
+                            '<div>' +
+                                '<div class="detail-title">Detalle de transaccion</div>' +
+                                '<div class="detail-subtitle">' + escapeHtml(txr.txhash || lookup) + '</div>' +
+                            '</div>' +
+                            '<span class="detail-pill ' + pillClass + '">' + escapeHtml(pillText) + '</span>' +
+                        '</div>' +
+                        '<div class="detail-grid">' +
+                            '<div class="detail-item"><div class="detail-key">Hash</div><div class="detail-value">' + escapeHtml(txr.txhash || lookup) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Altura de bloque</div><div class="detail-value">' + escapeHtml(txr.height ? fmt(txr.height) : '--') + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Timestamp</div><div class="detail-value">' + escapeHtml(txr.timestamp ? new Date(txr.timestamp).toLocaleString('es-HN') : '--') + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Gas usado</div><div class="detail-value">' + escapeHtml((txr.gas_used || '--') + ' / ' + (txr.gas_wanted || '--')) + '</div></div>' +
+                        '</div>' +
+                        '<div class="detail-section-title">Mensajes</div>' +
+                        '<div class="detail-table-wrap">' +
+                            '<table class="detail-table">' +
+                                '<thead><tr><th>#</th><th>Tipo</th><th>Sender</th><th>Receiver</th><th>Amount</th></tr></thead>' +
+                                '<tbody>' + rows + '</tbody>' +
+                            '</table>' +
+                        '</div>' +
+                    '</div>'
+                );
+            } catch (err) {
+                if (token !== explorerRouteToken) return;
+                renderExplorerError(
+                    friendlyLookupError(err, 'No encontramos esa transaccion.', 'No se pudo consultar la transaccion.'),
+                    lookup
+                );
+            }
+        }
+
+        async function renderAddressRoute(address, token) {
+            var lookup = (address || '').trim();
+            if (!lookup) {
+                renderExplorerError('Ingresa una direccion para consultar.', lookup);
+                return;
+            }
+            if (!looksLikeAddress(lookup)) {
+                renderExplorerError('Direccion invalida. Debe iniciar con ltd1...', lookup);
+                return;
+            }
+
+            renderExplorerLoading('Direccion', lookup);
+            try {
+                var eventQuery = "transfer.sender='" + lookup + "'";
+                var endpoints = await Promise.allSettled([
+                    fetchJSON(REST + '/cosmos/bank/v1beta1/balances/' + encodeURIComponent(lookup)),
+                    fetchJSON(REST + '/cosmos/staking/v1beta1/delegations/' + encodeURIComponent(lookup)),
+                    fetchJSON(REST + '/cosmos/tx/v1beta1/txs?events=' + encodeURIComponent(eventQuery) + '&pagination.limit=10')
+                ]);
+                if (token !== explorerRouteToken) return;
+
+                var balances = endpoints[0].status === 'fulfilled' ? (endpoints[0].value.balances || []) : [];
+                var delegations = endpoints[1].status === 'fulfilled' ? (endpoints[1].value.delegation_responses || []) : [];
+                var txs = endpoints[2].status === 'fulfilled' ? (endpoints[2].value.tx_responses || []) : [];
+
+                if (endpoints[0].status === 'rejected' && endpoints[1].status === 'rejected' && endpoints[2].status === 'rejected') {
+                    throw endpoints[0].reason || endpoints[1].reason || endpoints[2].reason;
+                }
+
+                var balancesRows = balances.length === 0
+                    ? '<tr><td colspan="2" class="loading">Sin balances visibles.</td></tr>'
+                    : balances.map(function(c) {
+                        return '<tr><td class="mono">' + escapeHtml(c.denom || '--') + '</td><td class="mono">' + escapeHtml(formatCoin(c)) + '</td></tr>';
+                    }).join('');
+
+                var delegationRows = delegations.length === 0
+                    ? '<tr><td colspan="3" class="loading">Sin delegaciones activas.</td></tr>'
+                    : delegations.map(function(d) {
+                        var entry = d.delegation || {};
+                        var balance = d.balance || {};
+                        return '<tr>' +
+                            '<td>' + routeLink(entry.validator_address || '') + '</td>' +
+                            '<td class="mono">' + escapeHtml((entry.shares || '--').toString()) + '</td>' +
+                            '<td class="mono">' + escapeHtml(formatCoin(balance)) + '</td>' +
+                        '</tr>';
+                    }).join('');
+
+                var txRows = txs.length === 0
+                    ? '<tr><td colspan="4" class="loading">Sin transacciones recientes para este sender.</td></tr>'
+                    : txs.map(function(txr) {
+                        var ts = txr.timestamp ? new Date(txr.timestamp).toLocaleString('es-HN') : '--';
+                        var status = Number(txr.code || 0) === 0 ? 'OK' : 'ERR';
+                        return '<tr>' +
+                            '<td>' + routeLink(txr.txhash || '') + '</td>' +
+                            '<td class="mono">#' + escapeHtml(txr.height ? fmt(txr.height) : '--') + '</td>' +
+                            '<td class="mono">' + escapeHtml(ts) + '</td>' +
+                            '<td class="mono">' + escapeHtml(status) + '</td>' +
+                        '</tr>';
+                    }).join('');
+
+                var delegationTotal = '--';
+                if (endpoints[1].status === 'fulfilled') {
+                    var total = endpoints[1].value.pagination && endpoints[1].value.pagination.total;
+                    delegationTotal = total !== undefined && total !== null && total !== '' ? fmt(total) : String(delegations.length);
+                }
+
+                setExplorerDetailHtml(
+                    '<div class="detail-card">' +
+                        '<div class="detail-header">' +
+                            '<div>' +
+                                '<div class="detail-title">Direccion</div>' +
+                                '<div class="detail-subtitle">' + escapeHtml(lookup) + '</div>' +
+                            '</div>' +
+                            '<span class="detail-pill ok">Activa</span>' +
+                        '</div>' +
+                        '<div class="detail-grid">' +
+                            '<div class="detail-item"><div class="detail-key">Balance tokens</div><div class="detail-value">' + escapeHtml(String(balances.length)) + ' denom</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Delegaciones</div><div class="detail-value">' + escapeHtml(String(delegationTotal)) + '</div></div>' +
+                        '</div>' +
+                        '<div class="detail-section-title">Balances</div>' +
+                        '<div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Denom</th><th>Monto</th></tr></thead><tbody>' + balancesRows + '</tbody></table></div>' +
+                        '<div class="detail-section-title">Delegaciones</div>' +
+                        '<div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Validador</th><th>Shares</th><th>Balance</th></tr></thead><tbody>' + delegationRows + '</tbody></table></div>' +
+                        '<div class="detail-section-title">Transacciones recientes (sender)</div>' +
+                        '<div class="detail-table-wrap"><table class="detail-table"><thead><tr><th>Hash</th><th>Bloque</th><th>Fecha</th><th>Status</th></tr></thead><tbody>' + txRows + '</tbody></table></div>' +
+                    '</div>'
+                );
+            } catch (err) {
+                if (token !== explorerRouteToken) return;
+                renderExplorerError(
+                    friendlyLookupError(err, 'No encontramos esa direccion.', 'No se pudieron cargar los datos de la direccion.'),
+                    lookup
+                );
+            }
+        }
+
+        async function renderValidatorRoute(operatorAddress, token) {
+            var lookup = (operatorAddress || '').trim();
+            if (!lookup) {
+                renderExplorerError('Ingresa una direccion de validador.', lookup);
+                return;
+            }
+            if (!looksLikeValidatorAddress(lookup)) {
+                renderExplorerError('Direccion de validador invalida. Debe iniciar con ltdvaloper1...', lookup);
+                return;
+            }
+
+            renderExplorerLoading('Validador', lookup);
+            try {
+                var data = await fetchJSON(REST + '/cosmos/staking/v1beta1/validators/' + encodeURIComponent(lookup));
+                if (token !== explorerRouteToken) return;
+
+                var validator = data.validator || {};
+                var delegatorAddress = operatorToDelegator(lookup);
+                var results = await Promise.allSettled([
+                    fetchJSON(REST + '/cosmos/staking/v1beta1/validators/' + encodeURIComponent(lookup) + '/delegations?pagination.limit=1&pagination.count_total=true'),
+                    delegatorAddress
+                        ? fetchJSON(REST + '/cosmos/staking/v1beta1/validators/' + encodeURIComponent(lookup) + '/delegations/' + encodeURIComponent(delegatorAddress))
+                        : Promise.resolve(null),
+                    fetchValidatorUptime(validator)
+                ]);
+                if (token !== explorerRouteToken) return;
+
+                var statusClass = validator.jailed ? 'err' : (validator.status === 'BOND_STATUS_BONDED' ? 'ok' : 'warn');
+                var statusText = validator.jailed ? 'Jailed' : (validator.status === 'BOND_STATUS_BONDED' ? 'Bonded' : 'No activo');
+                var commission = validator.commission && validator.commission.commission_rates
+                    ? (parseFloat(validator.commission.commission_rates.rate || '0') * 100).toFixed(2) + '%'
+                    : '--';
+
+                var delegatorCount = '--';
+                if (results[0].status === 'fulfilled') {
+                    var totalDelegators = results[0].value.pagination ? results[0].value.pagination.total : null;
+                    if (totalDelegators !== null && totalDelegators !== undefined && totalDelegators !== '') {
+                        delegatorCount = fmt(totalDelegators);
+                    } else {
+                        delegatorCount = String((results[0].value.delegation_responses || []).length);
+                    }
+                }
+
+                var selfDelegation = '--';
+                if (results[1].status === 'fulfilled' && results[1].value && results[1].value.delegation_response) {
+                    selfDelegation = formatCoin(results[1].value.delegation_response.balance);
+                }
+
+                var uptime = results[2].status === 'fulfilled' ? results[2].value : '--';
+                var moniker = validator.description ? (validator.description.moniker || '--') : '--';
+                var website = validator.description ? (validator.description.website || '--') : '--';
+
+                setExplorerDetailHtml(
+                    '<div class="detail-card">' +
+                        '<div class="detail-header">' +
+                            '<div>' +
+                                '<div class="detail-title">' + escapeHtml(moniker) + '</div>' +
+                                '<div class="detail-subtitle">' + escapeHtml(lookup) + '</div>' +
+                            '</div>' +
+                            '<span class="detail-pill ' + statusClass + '">' + escapeHtml(statusText) + '</span>' +
+                        '</div>' +
+                        '<div class="detail-grid">' +
+                            '<div class="detail-item"><div class="detail-key">Operator</div><div class="detail-value">' + escapeHtml(lookup) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Commission</div><div class="detail-value">' + escapeHtml(commission) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Tokens</div><div class="detail-value">' + escapeHtml(formatTokenAmount(validator.tokens || '0', 'ultd')) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Delegator count</div><div class="detail-value">' + escapeHtml(delegatorCount) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Uptime</div><div class="detail-value">' + escapeHtml(uptime) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Self-delegation</div><div class="detail-value">' + escapeHtml(selfDelegation) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Min self delegation</div><div class="detail-value">' + escapeHtml(formatTokenAmount(validator.min_self_delegation || '0', 'ultd')) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Cuenta base</div><div class="detail-value">' + (delegatorAddress ? routeLink(delegatorAddress) : '--') + '</div></div>' +
+                        '</div>' +
+                        '<div class="detail-section-title">Metadata</div>' +
+                        '<div class="detail-grid">' +
+                            '<div class="detail-item"><div class="detail-key">Website</div><div class="detail-value">' + escapeHtml(website) + '</div></div>' +
+                            '<div class="detail-item"><div class="detail-key">Detalle</div><div class="detail-value">' + escapeHtml(validator.description && validator.description.details ? validator.description.details : '--') + '</div></div>' +
+                        '</div>' +
+                    '</div>'
+                );
+            } catch (err) {
+                if (token !== explorerRouteToken) return;
+                renderExplorerError(
+                    friendlyLookupError(err, 'No encontramos ese validador.', 'No se pudo consultar ese validador.'),
+                    lookup
+                );
+            }
+        }
+
+        async function handleExplorerRoute(scrollIntoView) {
+            var route = parseExplorerRoute();
+            if (!route) return;
+
+            var token = ++explorerRouteToken;
+            var typeInput = document.getElementById('explorerSearchType');
+            var textInput = document.getElementById('explorerSearchInput');
+            if (typeInput) typeInput.value = route.kind;
+            if (textInput) textInput.value = route.value;
+
+            if (scrollIntoView) {
+                var explorer = document.getElementById('explorador');
+                if (explorer) explorer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+
+            if (route.kind === 'tx') {
+                await renderTxRoute(route.value, token);
+            } else if (route.kind === 'address') {
+                await renderAddressRoute(route.value, token);
+            } else if (route.kind === 'validator') {
+                await renderValidatorRoute(route.value, token);
+            }
+        }
+
+        var explorerSearchForm = document.getElementById('explorerSearchForm');
+        if (explorerSearchForm) {
+            explorerSearchForm.addEventListener('submit', function(ev) {
+                ev.preventDefault();
+                var type = document.getElementById('explorerSearchType').value || 'tx';
+                var input = document.getElementById('explorerSearchInput').value || '';
+                var parsed = parseInputRoute(input, type);
+                if (!parsed) {
+                    renderExplorerError('Escribe un valor para buscar.', input);
+                    return;
+                }
+                setExplorerHash(parsed.kind, parsed.value);
+            });
+        }
+
+        window.addEventListener('hashchange', function() {
+            handleExplorerRoute(true);
         });
 
         // ---- Data fetchers (reused from explorer) ----
@@ -1995,6 +2837,7 @@
                     ((bonded / 200000000000000) * 100).toFixed(3) + '% del suministro';
 
                 var validators = vals.validators || [];
+                latestValidators = validators.slice();
                 document.getElementById('validatorCount').textContent = validators.length;
                 document.getElementById('validatorSub').textContent = 'Activos (bonded)';
                 document.getElementById('valEpoch').textContent = validators.length + ' validador' + (validators.length !== 1 ? 'es' : '');
@@ -2073,13 +2916,14 @@
                 return;
             }
 
-            var sorted = validators.sort(function(a, b) { return Number(b.tokens) - Number(a.tokens); });
+            var sorted = validators.slice().sort(function(a, b) { return Number(b.tokens) - Number(a.tokens); });
 
             container.innerHTML = sorted.map(function(v, i) {
                 var tokens = Number(v.tokens);
                 var pct = totalBonded > 0 ? ((tokens / totalBonded) * 100).toFixed(1) : '0';
                 var commission = (parseFloat(v.commission.commission_rates.rate) * 100).toFixed(0);
                 var jailed = v.jailed;
+                var detailHref = routeHref('validator', v.operator_address);
 
                 return '<div class="validator-card">' +
                     '<div class="val-info">' +
@@ -2095,6 +2939,7 @@
                         '<div><div class="val-stat-label">Comision</div><div class="val-stat-value">' + escapeHtml(commission) + '%</div></div>' +
                         '<div><div class="val-stat-label">Estado</div><div class="val-stat-value"><span class="status-bonded">' +
                             (jailed ? 'Jailed' : 'Activo') + '</span></div></div>' +
+                        '<div><div class="val-stat-label">Detalle</div><div class="val-stat-value"><a class="route-link" href="' + detailHref + '">Abrir</a></div></div>' +
                     '</div>' +
                 '</div>';
             }).join('');
@@ -2119,6 +2964,12 @@
                 fetchRecentBlocks(),
                 fetchGenesisHash()
             ]);
+
+            if (parseExplorerRoute()) {
+                await handleExplorerRoute(false);
+            } else {
+                renderExplorerWelcome();
+            }
 
             // Refresh status + blocks every 5s
             setInterval(refresh, REFRESH_MS);


### PR DESCRIPTION
## Summary
Implements the chain explorer enhancements requested in #89 inside `chain/index.html`.

## What changed
- Added a new explorer search/detail module with:
  - Search form (`Transaccion`, `Direccion`, `Validador`)
  - Route-aware detail panel
  - Inline route hints for hash URLs
- Added URL hash routing support:
  - `#tx/{hash}`
  - `#address/{addr}`
  - `#validator/{addr}`
- Added transaction detail lookup via:
  - `GET /chain/api/cosmos/tx/v1beta1/txs/{hash}`
  - Displays hash, height, timestamp, gas usage, and decoded message rows
- Added address detail lookup via:
  - `GET /chain/api/cosmos/bank/v1beta1/balances/{address}`
  - `GET /chain/api/cosmos/staking/v1beta1/delegations/{address}`
  - `GET /chain/api/cosmos/tx/v1beta1/txs?events=transfer.sender='{address}'`
  - Displays balances, delegations, and recent tx table
- Added validator detail lookup via:
  - `GET /chain/api/cosmos/staking/v1beta1/validators/{operator_address}`
  - Plus delegated count/self-delegation lookups
  - Displays moniker, operator, commission, delegator count, uptime estimate, self-delegation, min self-delegation
- Validator cards now include direct detail links (`#validator/{addr}`)
- Added mobile-responsive styles for the new search/detail UI

## Security / input handling
- All user-visible lookup content is rendered through `escapeHtml()` in the new detail renderer paths.
- Route values are URL-encoded before navigation/fetch.

## Validation done
- Verified live API response shapes for validator/delegation/slashing endpoints to map fields correctly.
- `git apply --check` passes for generated patch against upstream `main` explorer file.

## Notes
- Address tx history uses the exact event filter from the bounty requirement (`transfer.sender='{address}'`).
- Uptime is derived from slashing signing info window (`missed_blocks_counter` vs `signed_blocks_window`) when available.

Closes #89
