### PR TITLE
fix(accessibility): add aria-label to mobile drawer close button (#154)

### DIFF
--- a/home-dashboard.html
+++ b/home-dashboard.html
@@ -1276,7 +1276,7 @@
                 </div>
                 <span class="mobile-drawer-title">La Tanda</span>
             </div>
-            <button class="mobile-drawer-close" data-action="drawer-close">
+            <button class="mobile-drawer-close" data-action="drawer-close" aria-label="Cerrar menú">
                 <i class="fas fa-times"></i>
             </button>
         </div>


### PR DESCRIPTION
## Description

Adds missing `aria-label="Cerrar menú"` to the mobile drawer close button in `home-dashboard.html`.

### Changes
- Added `aria-label="Cerrar menú"` to the `mobile-drawer-close` button (line ~1279)
- Button only contains an `<i class="fas fa-times"></i>` icon with no visible text

### Verification (answering bounty question)
> How many `<button>` elements are in `home-dashboard.html` that contain only an `<i>` icon and no text? Name 3 of them with their current classes.

There is **1** button element in `home-dashboard.html` that contains only an `<i>` icon with no text:
1. `<button class="mobile-drawer-close" data-action="drawer-close">` — contains only `<i class="fas fa-times"></i>`

The other icon-only buttons already have `aria-label` attributes:
- `<button class="mobile-fab" ... aria-label="Crear publicación">`
- `<button class="mobile-nav-item" data-action="toggle-left-drawer" aria-label="Abrir menú">`
- `<button class="mobile-nav-item" data-action="toggle-right-drawer" aria-label="Abrir widgets">`

### Related Issue
Fixes INDIGOAZUL/la-tanda-web#154
