### PR TITLE
Add aria-label to mobile-drawer-close button (fixes #154)

### DIFF
--- a/home-dashboard.html
+++ b/home-dashboard.html
@@ -1276,7 +1276,7 @@
                 </div>
                 <span class="mobile-drawer-title">La Tanda</span>
             </div>
-            <button class="mobile-drawer-close" data-action="drawer-close">
+            <button class="mobile-drawer-close" data-action="drawer-close" aria-label="Cerrar">
                 <i class="fas fa-times"></i>
             </button>
         </div>


### PR DESCRIPTION
## Summary

Added aria-label='Cerrar' to the mobile drawer close button in home-dashboard.html which was missing accessibility labeling.

## Changes

- **File:** home-dashboard.html
- **Change:** Added ria-label='Cerrar' to <button class='mobile-drawer-close'> which was the only icon-only button in the file without an accessible label.

## Verification

Answer to the bounty verification question: **There are 3 button elements in home-dashboard.html that contain only an icon (no visible text in a span):**

1. 
av-post-btn (line 1142) - has icon + plain text 'Publicar' (no span)
2. mobile-drawer-close (line 1279) - **this fix** - icon only
3. mobile-fab (line 1409) - has icon + aria-label 'Crear publicacion'

The mobile-drawer-close button was the only one missing an ria-label.

Closes INDIGOAZUL/la-tanda-web#154