### PR TITLE
#Fix 154 : Add aria-labels to home-dashboard.html icon buttons  

### DIFF
--- a/home-dashboard.html
+++ b/home-dashboard.html
@@ -1276,7 +1276,7 @@
                 </div>
                 <span class="mobile-drawer-title">La Tanda</span>
             </div>
-            <button class="mobile-drawer-close" data-action="drawer-close">
+            <button class="mobile-drawer-close" data-action="drawer-close" aria-label="Cerrar menú">
                 <i class="fas fa-times"></i>
             </button>
         </div>


### PR DESCRIPTION
Fixes #154

## Overview

This PR improves accessibility in `home-dashboard.html` by adding a missing `aria-label="Cerrar menú"` to the `.mobile-drawer-close` icon-only button (with `fa-times`). It also verifies that the `.mobile-fab` button (with `fa-plus`) already had an appropriate `aria-label`.

As a result, all icon-only buttons now include descriptive Spanish `aria-label`s. No visual or behavioral changes were introduced.

## Verification Answer

There are 2 `<button>` elements that contain only an `<i>` icon and no text:

1. `.mobile-drawer-close` added `aria-label`
2. `.mobile-fab` already had `aria-label`

## Definition of Done

* [x] All icon-only buttons have `aria-label`
* [x] Labels are in Spanish
* [x] No functional changes
* [x] No console errors
