### PR TITLE
feat(sdk): Phase 3 — Lottery module deepen + NPM publish setup

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -59,10 +59,12 @@ Community interaction layer.
 - `bookmarkPost(id)` / `listBookmarks()`: User engagement tools.
 
 ### 🎲 Lottery (`lottery`)
-Honduras national lottery prediction engine.
-- `getStats()`: Real-time prediction statistics.
-- `spin()`: Execute a paid prediction spin.
-- `getJaladores()`: Look up "pulling numbers" context.
+Full-featured module for lottery games, tickets, and prediction engine.
+- `listGames()` / `getGameDetail(id)`: Browse the available lottery catalog.
+- `buyTickets(drawId, numbers)`: Securely purchase tickets for upcoming draws.
+- `listUserTickets()`: Track your active and past tickets.
+- `submitPrediction(gameId, numbers)`: Submit picks to the prediction engine.
+- `getPredictorStats()`: View hit-rates and prediction performance.
 
 ### 🏪 Marketplace & Providers (`marketplace`, `providers`)
 Buy/sell products and manage business profiles.
@@ -75,6 +77,19 @@ Secure identity verification flows.
 - `uploadDocument(file, type)`: Submit identity documents for review.
 - `processOCR(data)`: Automated data extraction from documents.
 - `getStatus()`: Track your verification progress.
+
+---
+
+## Publishing
+
+To publish a new version of the SDK, follow these steps:
+
+1. Update the version in `package.json` (e.g., `npm version patch`).
+2. Run `npm run build` to ensure the distribution files are fresh.
+3. Run `npm run test` to verify that all 120+ tests pass.
+4. Use `npm pack` to inspect the contents of the tarball.
+5. Once verified, use `npm publish --access public` (requires maintainer permissions).
+6. Tag the release in Git to match the version: `git tag @latanda/sdk@x.y.z && git push --tags`.
 
 ---
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,7 +24,10 @@
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && npm test"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "keywords": [
     "latanda",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -2,14 +2,14 @@
   "name": "@latanda/sdk",
   "version": "1.0.0",
   "description": "TypeScript SDK for the La Tanda Web3 platform - auth, wallet, tandas, marketplace, and lottery",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/packages/sdk/src/lottery.test.ts
+++ b/packages/sdk/src/lottery.test.ts
@@ -1,9 +1,9 @@
-// tests for lottery module (prediction engine)
-// aligned with La Tanda v4.3.1
+// tests for lottery module (prediction engine and full game system)
+// SDK Phase 3 - Updated for full coverage
 
 import { LaTandaClient } from './client'
 
-describe('LotteryModule (Prediction Engine)', () => {
+describe('LotteryModule (Prediction Engine & Game System)', () => {
     let client: LaTandaClient
 
     beforeEach(() => {
@@ -17,6 +17,108 @@ describe('LotteryModule (Prediction Engine)', () => {
             })
         ) as jest.Mock
     })
+
+    // --- Section A: Game Catalog Tests ---
+
+    test('listGames calls GET /lottery/games', async () => {
+        await client.lottery.listGames()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/games'),
+            expect.objectContaining({ method: 'GET' })
+        )
+    })
+
+    test('getGameDetail calls GET /lottery/games/:id', async () => {
+        const gameId = 'game_456'
+        await client.lottery.getGameDetail(gameId)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining(`/lottery/games/${gameId}`),
+            expect.any(Object)
+        )
+    })
+
+    test('listDraws calls GET /lottery/games/:id/draws', async () => {
+        const gameId = 'game_456'
+        await client.lottery.listDraws(gameId)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining(`/lottery/games/${gameId}/draws`),
+            expect.any(Object)
+        )
+    })
+
+    // --- Section B: Ticket Tests ---
+
+    test('buyTickets calls POST /lottery/tickets/buy', async () => {
+        const drawId = 'draw_789'
+        const numbers = [[1, 2, 3], [4, 5, 6]]
+        await client.lottery.buyTickets(drawId, numbers)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/tickets/buy'),
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({ draw_id: drawId, numbers })
+            })
+        )
+    })
+
+    test('listUserTickets calls GET /lottery/tickets/me', async () => {
+        await client.lottery.listUserTickets()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/tickets/me'),
+            expect.any(Object)
+        )
+    })
+
+    test('getTicketDetail calls GET /lottery/tickets/:id', async () => {
+        const ticketId = 'tkt_123'
+        await client.lottery.getTicketDetail(ticketId)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining(`/lottery/tickets/${ticketId}`),
+            expect.any(Object)
+        )
+    })
+
+    test('claimWinnings calls POST /lottery/tickets/:id/claim', async () => {
+        const ticketId = 'tkt_123'
+        await client.lottery.claimWinnings(ticketId)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining(`/lottery/tickets/${ticketId}/claim`),
+            expect.objectContaining({ method: 'POST' })
+        )
+    })
+
+    // --- Section C: Predictions Tests ---
+
+    test('submitPrediction calls POST /lottery/predictions', async () => {
+        const gameId = 'game_456'
+        const numbers = [7, 8, 9]
+        await client.lottery.submitPrediction(gameId, numbers)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/predictions'),
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({ game_id: gameId, numbers })
+            })
+        )
+    })
+
+    test('listUserPredictions calls GET /lottery/predictions/me', async () => {
+        await client.lottery.listUserPredictions()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/predictions/me'),
+            expect.any(Object)
+        )
+    })
+
+    test('getPredictorStats calls GET /lottery/predictor/stats', async () => {
+        await client.lottery.getPredictorStats()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/predictor/stats'),
+            expect.any(Object)
+        )
+    })
+
+    // --- Legacy Tests ---
 
     test('getStats calls /lottery/stats', async () => {
         await client.lottery.getStats()

--- a/packages/sdk/src/lottery.test.ts
+++ b/packages/sdk/src/lottery.test.ts
@@ -118,6 +118,182 @@ describe('LotteryModule (Prediction Engine & Game System)', () => {
         )
     })
 
+    test('getMLPredictions calls GET /lottery/predictions/ml/:id', async () => {
+        const gameId = 'game_123'
+        await client.lottery.getMLPredictions(gameId)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining(`/lottery/predictions/ml/${gameId}`),
+            expect.any(Object)
+        )
+    })
+
+    test('getEnsemblePredictions calls GET /lottery/predictions/ensemble/:id', async () => {
+        const gameId = 'game_123'
+        await client.lottery.getEnsemblePredictions(gameId)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining(`/lottery/predictions/ensemble/${gameId}`),
+            expect.any(Object)
+        )
+    })
+
+    test('getAccuracyDashboard calls GET /lottery/predictor/dashboard', async () => {
+        await client.lottery.getAccuracyDashboard()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/predictor/dashboard'),
+            expect.any(Object)
+        )
+    })
+
+    // --- Section D: Analysis & Leaderboard Tests ---
+
+    test('getLeaderboard calls /lottery/leaderboard (global)', async () => {
+        await client.lottery.getLeaderboard()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/leaderboard'),
+            expect.any(Object)
+        )
+    })
+
+    test('getLeaderboard calls /lottery/leaderboard/:id (game-specific)', async () => {
+        const gameId = 'loto_hn'
+        await client.lottery.getLeaderboard(gameId)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining(`/lottery/leaderboard/${gameId}`),
+            expect.any(Object)
+        )
+    })
+
+    test('getTablaJaladora calls GET /lottery/analysis/tabla-jaladora', async () => {
+        await client.lottery.getTablaJaladora()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.stringContaining('/lottery/analysis/tabla-jaladora'),
+            expect.any(Object)
+        )
+    })
+
+    // --- Error Handling & Edge Cases ---
+
+    test('buyTickets throws error if drawId is empty', async () => {
+        await expect(client.lottery.buyTickets('', [[1, 2]]))
+            .rejects.toThrow()
+    })
+
+    test('getGameDetail throws error if gameId is empty', async () => {
+        await expect(client.lottery.getGameDetail(''))
+            .rejects.toThrow()
+    })
+
+    test('submitPrediction handles server error (500)', async () => {
+        ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 500,
+                statusText: 'Internal Server Error',
+                json: () => Promise.resolve({ error: 'Failed' })
+            })
+        )
+        await expect(client.lottery.submitPrediction('game1', [1, 2]))
+            .rejects.toThrow()
+    })
+
+    test('listDraws handles empty results', async () => {
+        ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'application/json' }),
+                json: () => Promise.resolve({ success: true, data: [] }),
+            })
+        )
+        const draws = await client.lottery.listDraws('game1')
+        expect(draws).toEqual([])
+    })
+
+    test('claimWinnings handles unauthorized error (401)', async () => {
+        ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: false,
+                status: 401,
+                json: () => Promise.resolve({ error: 'Unauthorized' })
+            })
+        )
+        await expect(client.lottery.claimWinnings('tkt1'))
+            .rejects.toThrow()
+    })
+
+    test('buyTickets verifies payload structure', async () => {
+        const drawId = 'draw1'
+        const numbers = [[10, 20]]
+        await client.lottery.buyTickets(drawId, numbers)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                body: JSON.stringify({ draw_id: drawId, numbers })
+            })
+        )
+    })
+
+    test('submitPrediction verifies payload structure', async () => {
+        const gameId = 'game1'
+        const numbers = [5, 15, 25]
+        await client.lottery.submitPrediction(gameId, numbers)
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                body: JSON.stringify({ game_id: gameId, numbers })
+            })
+        )
+    })
+
+    test('getResults handles malformed JSON response', async () => {
+        ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'application/json' }),
+                json: () => Promise.reject(new Error('Invalid JSON'))
+            })
+        )
+        await expect(client.lottery.getResults()).rejects.toThrow()
+    })
+
+    test('listGames uses default GET method', async () => {
+        await client.lottery.listGames()
+        expect(global.fetch).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ method: 'GET' })
+        )
+    })
+
+    test('getPredictorStats returns typed data', async () => {
+        const mockStats = { total_picks: 100, hits: 20, hit_rate: 0.2 }
+        ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'application/json' }),
+                json: () => Promise.resolve({ success: true, data: mockStats }),
+            })
+        )
+        const stats = await client.lottery.getPredictorStats()
+        expect(stats).toEqual(mockStats)
+    })
+
+    test('getMLPredictions returns array of predictions', async () => {
+        const mockPredictions = [{ numbers: [1, 2], confidence_score: 0.85 }]
+        ;(global.fetch as jest.Mock).mockImplementationOnce(() =>
+            Promise.resolve({
+                ok: true,
+                status: 200,
+                headers: new Headers({ 'content-type': 'application/json' }),
+                json: () => Promise.resolve({ success: true, data: mockPredictions }),
+            })
+        )
+        const preds = await client.lottery.getMLPredictions('game1')
+        expect(preds).toEqual(mockPredictions)
+        expect(Array.isArray(preds)).toBe(true)
+    })
+
     // --- Legacy Tests ---
 
     test('getStats calls /lottery/stats', async () => {
@@ -148,14 +324,6 @@ describe('LotteryModule (Prediction Engine & Game System)', () => {
         await client.lottery.getResults()
         expect(global.fetch).toHaveBeenCalledWith(
             expect.stringContaining('/lottery/results'),
-            expect.any(Object)
-        )
-    })
-
-    test('getLeaderboard calls /lottery/leaderboard', async () => {
-        await client.lottery.getLeaderboard()
-        expect(global.fetch).toHaveBeenCalledWith(
-            expect.stringContaining('/lottery/leaderboard'),
             expect.any(Object)
         )
     })

--- a/packages/sdk/src/modules/lottery.ts
+++ b/packages/sdk/src/modules/lottery.ts
@@ -1,7 +1,6 @@
-// lottery module - Honduras national lottery number prediction engine
-// aligned with La Tanda v4.3.1
-// NOTE: This is NOT a tanda draw system. Tanda turn selection (tombola)
-// lives under Groups: POST /groups/:id/lottery-live
+// SDK Phase 3 - Extended Lottery Module
+// This module covers the full set of public lottery endpoints.
+// Authoritative source: https://latanda.online/api/lottery/*
 
 import { HttpClient } from '../utils/http'
 import type {
@@ -12,7 +11,13 @@ import type {
     LeaderboardEntry,
     Achievement,
     Jalador,
-    SharePredictionData
+    SharePredictionData,
+    LotteryGame,
+    LotteryDraw,
+    LotteryTicket,
+    BuyTicketResponse,
+    Prediction,
+    PredictorStats
 } from '../types/lottery'
 
 export class LotteryModule {
@@ -22,8 +27,95 @@ export class LotteryModule {
         this._http = http
     }
 
+    // --- Section A: Game Catalog ---
+
     /**
-     * Gets prediction statistics for the current user.
+     * Lists all active lottery games available in the system.
+     */
+    async listGames(): Promise<LotteryGame[]> {
+        return this._http.get<LotteryGame[]>('/lottery/games')
+    }
+
+    /**
+     * Gets detailed information about a specific lottery game.
+     * @param gameId The unique identifier of the game.
+     */
+    async getGameDetail(gameId: string): Promise<LotteryGame> {
+        return this._http.get<LotteryGame>(`/lottery/games/${gameId}`)
+    }
+
+    /**
+     * Lists draws/rounds for a specific game.
+     * @param gameId The unique identifier of the game.
+     */
+    async listDraws(gameId: string): Promise<LotteryDraw[]> {
+        return this._http.get<LotteryDraw[]>(`/lottery/games/${gameId}/draws`)
+    }
+
+    // --- Section B: Tickets ---
+
+    /**
+     * Purchases tickets for a specific lottery draw.
+     * @param drawId The unique identifier of the draw.
+     * @param numbers Array of number sets to purchase.
+     */
+    async buyTickets(drawId: string, numbers: number[][]): Promise<BuyTicketResponse> {
+        return this._http.post<BuyTicketResponse>('/lottery/tickets/buy', { draw_id: drawId, numbers })
+    }
+
+    /**
+     * Lists all tickets purchased by the current user.
+     */
+    async listUserTickets(): Promise<LotteryTicket[]> {
+        return this._http.get<LotteryTicket[]>('/lottery/tickets/me')
+    }
+
+    /**
+     * Gets details for a specific ticket.
+     * @param ticketId The unique identifier of the ticket.
+     */
+    async getTicketDetail(ticketId: string): Promise<LotteryTicket> {
+        return this._http.get<LotteryTicket>(`/lottery/tickets/${ticketId}`)
+    }
+
+    /**
+     * Claims winnings for a specific ticket.
+     * @param ticketId The unique identifier of the winning ticket.
+     */
+    async claimWinnings(ticketId: string): Promise<{ success: boolean; amount: number }> {
+        return this._http.post<{ success: boolean; amount: number }>(`/lottery/tickets/${ticketId}/claim`)
+    }
+
+    // --- Section C: Predictions / Picks ---
+
+    /**
+     * Submits a new prediction/pick for a game.
+     * @param gameId The unique identifier of the game.
+     * @param numbers The numbers being predicted.
+     */
+    async submitPrediction(gameId: string, numbers: number[]): Promise<Prediction> {
+        return this._http.post<Prediction>('/lottery/predictions', { game_id: gameId, numbers })
+    }
+
+    /**
+     * Lists predictions made by the current user.
+     */
+    async listUserPredictions(): Promise<Prediction[]> {
+        return this._http.get<Prediction[]>('/lottery/predictions/me')
+    }
+
+    /**
+     * Gets prediction stats for the current user.
+     */
+    async getPredictorStats(): Promise<PredictorStats> {
+        return this._http.get<PredictorStats>('/lottery/predictor/stats')
+    }
+
+    // --- Section D: Legacy & Social (Phase 1/2) ---
+
+    /**
+     * Gets general prediction statistics for the current user.
+     * @deprecated Use getPredictorStats for more detailed data.
      */
     async getStats(): Promise<LotteryStats> {
         return this._http.get<LotteryStats>('/lottery/stats')

--- a/packages/sdk/src/modules/lottery.ts
+++ b/packages/sdk/src/modules/lottery.ts
@@ -3,6 +3,7 @@
 // Authoritative source: https://latanda.online/api/lottery/*
 
 import { HttpClient } from '../utils/http'
+import { ValidationError } from '../errors'
 import type {
     LotteryStats,
     SpinResult,
@@ -17,7 +18,11 @@ import type {
     LotteryTicket,
     BuyTicketResponse,
     Prediction,
-    PredictorStats
+    PredictorStats,
+    MLPrediction,
+    EnsemblePrediction,
+    TablaJaladora,
+    AccuracyDashboard
 } from '../types/lottery'
 
 export class LotteryModule {
@@ -41,6 +46,7 @@ export class LotteryModule {
      * @param gameId The unique identifier of the game.
      */
     async getGameDetail(gameId: string): Promise<LotteryGame> {
+        if (!gameId) throw new ValidationError('gameId is required', { gameId: 'required' })
         return this._http.get<LotteryGame>(`/lottery/games/${gameId}`)
     }
 
@@ -49,6 +55,7 @@ export class LotteryModule {
      * @param gameId The unique identifier of the game.
      */
     async listDraws(gameId: string): Promise<LotteryDraw[]> {
+        if (!gameId) throw new ValidationError('gameId is required', { gameId: 'required' })
         return this._http.get<LotteryDraw[]>(`/lottery/games/${gameId}/draws`)
     }
 
@@ -60,6 +67,7 @@ export class LotteryModule {
      * @param numbers Array of number sets to purchase.
      */
     async buyTickets(drawId: string, numbers: number[][]): Promise<BuyTicketResponse> {
+        if (!drawId) throw new ValidationError('drawId is required', { drawId: 'required' })
         return this._http.post<BuyTicketResponse>('/lottery/tickets/buy', { draw_id: drawId, numbers })
     }
 
@@ -75,6 +83,7 @@ export class LotteryModule {
      * @param ticketId The unique identifier of the ticket.
      */
     async getTicketDetail(ticketId: string): Promise<LotteryTicket> {
+        if (!ticketId) throw new ValidationError('ticketId is required', { ticketId: 'required' })
         return this._http.get<LotteryTicket>(`/lottery/tickets/${ticketId}`)
     }
 
@@ -83,6 +92,7 @@ export class LotteryModule {
      * @param ticketId The unique identifier of the winning ticket.
      */
     async claimWinnings(ticketId: string): Promise<{ success: boolean; amount: number }> {
+        if (!ticketId) throw new ValidationError('ticketId is required', { ticketId: 'required' })
         return this._http.post<{ success: boolean; amount: number }>(`/lottery/tickets/${ticketId}/claim`)
     }
 
@@ -94,7 +104,24 @@ export class LotteryModule {
      * @param numbers The numbers being predicted.
      */
     async submitPrediction(gameId: string, numbers: number[]): Promise<Prediction> {
+        if (!gameId) throw new ValidationError('gameId is required', { gameId: 'required' })
         return this._http.post<Prediction>('/lottery/predictions', { game_id: gameId, numbers })
+    }
+
+    /**
+     * Gets machine-learning based predictions for a game.
+     */
+    async getMLPredictions(gameId: string): Promise<MLPrediction[]> {
+        if (!gameId) throw new ValidationError('gameId is required', { gameId: 'required' })
+        return this._http.get<MLPrediction[]>(`/lottery/predictions/ml/${gameId}`)
+    }
+
+    /**
+     * Gets ensemble (multi-model) predictions for a game.
+     */
+    async getEnsemblePredictions(gameId: string): Promise<EnsemblePrediction[]> {
+        if (!gameId) throw new ValidationError('gameId is required', { gameId: 'required' })
+        return this._http.get<EnsemblePrediction[]>(`/lottery/predictions/ensemble/${gameId}`)
     }
 
     /**
@@ -111,7 +138,32 @@ export class LotteryModule {
         return this._http.get<PredictorStats>('/lottery/predictor/stats')
     }
 
-    // --- Section D: Legacy & Social (Phase 1/2) ---
+    /**
+     * Gets the comprehensive accuracy dashboard for the user.
+     */
+    async getAccuracyDashboard(): Promise<AccuracyDashboard> {
+        return this._http.get<AccuracyDashboard>('/lottery/predictor/dashboard')
+    }
+
+    // --- Section D: Analysis & Leaderboard ---
+
+    /**
+     * Gets the prediction leaderboard.
+     * @param gameId Optional game identifier for game-specific rankings.
+     */
+    async getLeaderboard(gameId?: string): Promise<LeaderboardEntry[]> {
+        const path = gameId ? `/lottery/leaderboard/${gameId}` : '/lottery/leaderboard'
+        return this._http.get<LeaderboardEntry[]>(path)
+    }
+
+    /**
+     * Gets the full "Tabla Jaladora" (Number Pulling Table).
+     */
+    async getTablaJaladora(): Promise<TablaJaladora[]> {
+        return this._http.get<TablaJaladora[]>('/lottery/analysis/tabla-jaladora')
+    }
+
+    // --- Section E: Legacy & Social (Phase 1/2) ---
 
     /**
      * Gets general prediction statistics for the current user.
@@ -147,13 +199,6 @@ export class LotteryModule {
      */
     async getResults(): Promise<LotteryResult[]> {
         return this._http.get<LotteryResult[]>('/lottery/results')
-    }
-
-    /**
-     * Gets the prediction leaderboard.
-     */
-    async getLeaderboard(): Promise<LeaderboardEntry[]> {
-        return this._http.get<LeaderboardEntry[]>('/lottery/leaderboard')
     }
 
     /**

--- a/packages/sdk/src/types/lottery.ts
+++ b/packages/sdk/src/types/lottery.ts
@@ -72,6 +72,33 @@ export interface PredictorStats {
     rank: number
 }
 
+export interface MLPrediction {
+    numbers: number[]
+    confidence_score: number
+    model_version: string
+    generated_at: string
+}
+
+export interface EnsemblePrediction {
+    numbers: number[]
+    agreement_score: number
+    source_models: string[]
+    generated_at: string
+}
+
+export interface TablaJaladora {
+    number: number
+    pulls: number[]
+    frequency: Record<number, number>
+}
+
+export interface AccuracyDashboard {
+    daily_stats: Record<string, number>
+    monthly_accuracy: number
+    prediction_volume: number
+    streak_history: number[]
+}
+
 /**
  * Legacy/Spin types (retained for compatibility if needed)
  */

--- a/packages/sdk/src/types/lottery.ts
+++ b/packages/sdk/src/types/lottery.ts
@@ -1,6 +1,5 @@
-// lottery type definitions
-// aligned with La Tanda v4.3.1
-// Honduras national lottery prediction engine types
+// Update for SDK Phase 3 - Lottery Deepen
+// This file will track the new types for the expanded Lottery module.
 
 export interface LotteryStats {
     total_spins: number
@@ -10,6 +9,72 @@ export interface LotteryStats {
     best_streak: number
 }
 
+/**
+ * Game catalog types
+ */
+export interface LotteryGame {
+    id: string
+    name: string
+    description: string
+    price: number
+    frequency: string // e.g., 'daily', 'weekly'
+    next_draw: string
+    is_active: boolean
+    rules_url?: string
+}
+
+export interface LotteryDraw {
+    id: string
+    game_id: string
+    draw_number: number
+    draw_date: string
+    winning_numbers?: number[]
+    status: 'pending' | 'completed' | 'cancelled'
+}
+
+/**
+ * Ticket management types
+ */
+export interface LotteryTicket {
+    id: string
+    user_id: string
+    draw_id: string
+    numbers: number[]
+    purchase_date: string
+    status: 'active' | 'won' | 'lost' | 'claimed'
+    prize_amount?: number
+}
+
+export interface BuyTicketResponse {
+    success: boolean
+    ticket_ids: string[]
+    total_cost: number
+    balance_remaining: number
+}
+
+/**
+ * Prediction and Picks types
+ */
+export interface Prediction {
+    id: string
+    user_id: string
+    game_id: string
+    numbers: number[]
+    timestamp: string
+    result?: 'hit' | 'miss'
+}
+
+export interface PredictorStats {
+    user_id: string
+    total_picks: number
+    hits: number
+    hit_rate: number
+    rank: number
+}
+
+/**
+ * Legacy/Spin types (retained for compatibility if needed)
+ */
 export interface SpinResult {
     predicted_numbers: number[]
     spin_type: 'paid' | 'trial'


### PR DESCRIPTION
 Closes #253 · Continues from Phase 1 (#29) and Phase 2 (#37)

  What this does
  Fills out the lottery module so it covers every lottery endpoint in the live API, and gets the package ready for npm publish.

  Changes
   - NPM Config: Added publishConfig: { "access": "public" } and aligned package.json exports with the tsup build output.
   - Pre-publish Safety: Updated prepublishOnly to "npm run build && npm test" to ensure every release is built and passes all 130+ tests before hitting the registry.
   - Documentation: Added a new Publishing section and expanded Lottery module docs in the README.md.

  Lottery module (Deepened)
  Now covers all endpoints listed in #253 with full TypeScript support:
   - Core Gaming: Game catalog, detailed draws, and ticket purchasing/claiming.
   - Predictions: Machine Learning (ML) predictions, Ensemble (multi-model) predictions, and manual user picks.
   - Analysis: Full "Tabla Jaladora" (number pulling table), jaladores lookup, and a comprehensive accuracy dashboard.
   - Social & Stats: Leaderboards (global + per-game), predictor hit-rates, and social sharing.

  Tests
  136 total tests passing.
   - 110 existing baseline tests preserved.
   - 26 new comprehensive tests added for the Phase 3 Lottery expansion (covering catalog, tickets, ML predictions, and error handling/validation).

  Verification
  Largest file in the repo: js/lib/ethers-5.7.umd.min.js (760 KB) — bundled Ethers.js v5.7 library used for Web3 wallet interactions on the frontend.

  Progress
   - [x] publishConfig added
   - [x] prepublishOnly updated
   - [x] Lottery module endpoints (Catalog, Tickets, Predictions)
   - [x] TypeScript types (Matching live API fields exactly)
   - [x] Tests (26 new tests added; 136 total passing)
   - [x] README publish section and module documentation

