### PR TITLE
Fix broken placeholder links across HTML pages

### DIFF
--- a/auth-enhanced.html
+++ b/auth-enhanced.html
@@ -983,11 +983,11 @@
                     <div class="error-message" id="loginPasswordError"></div>
                 </div>
                 
-                <a href="#" class="forgot-password" onclick="window.auth.showPasswordResetForm(); return false;">
+                <button type="button" class="forgot-password" onclick="window.auth.showPasswordResetForm(); return false;">
                     ¿Olvidaste tu contraseña?
-                </a>
+                </button>
                 <div style="text-align:center;margin-top:8px;">
-                    <a href="#" style="color:rgba(255,255,255,0.35);font-size:0.78rem;text-decoration:none;" onclick="var em=document.getElementById('loginEmail').value.trim(); if(!em||!window.auth.validateEmail(em)){window.auth.showError('Ingresa tu email primero');document.getElementById('loginEmail').focus();return false;} window.auth.showInfo('Enviando codigo...'); fetch('/api/auth/send-verification',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:em})}).then(function(r){return r.json()}).then(function(){window.auth.showEmailVerificationForm(em)}).catch(function(){window.auth.showEmailVerificationForm(em)}); return false;">¿Ya te registraste pero no verificaste tu email?</a>
+                    <button type="button" style="color:rgba(255,255,255,0.35);font-size:0.78rem;text-decoration:none;background:none;border:0;padding:0;cursor:pointer;" onclick="var em=document.getElementById('loginEmail').value.trim(); if(!em||!window.auth.validateEmail(em)){window.auth.showError('Ingresa tu email primero');document.getElementById('loginEmail').focus();return false;} window.auth.showInfo('Enviando codigo...'); fetch('/api/auth/send-verification',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:em})}).then(function(r){return r.json()}).then(function(){window.auth.showEmailVerificationForm(em)}).catch(function(){window.auth.showEmailVerificationForm(em)}); return false;">¿Ya te registraste pero no verificaste tu email?</button>
                 </div>
                 
                 <button type="submit" class="btn-primary" id="loginSubmit">
@@ -1081,7 +1081,7 @@
                 <div class="checkbox-container">
                     <input type="checkbox" id="acceptTerms" required>
                     <label for="acceptTerms">
-                        Acepto los <a href="#" target="_blank" rel="noopener noreferrer">Términos y Condiciones</a>
+                        Acepto los <a href="terms-of-service.html" target="_blank" rel="noopener noreferrer">Términos y Condiciones</a>
                     </label>
                 </div>
                 

--- a/creator-hub.html
+++ b/creator-hub.html
@@ -1925,19 +1925,19 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="guardados.html" class="more-menu-item">
                         <i class="fas fa-list"></i>
                         <span>Listas</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="groups-advanced-system.html" class="more-menu-item">
                         <i class="fas fa-users"></i>
                         <span>Comunidades</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="trabajo.html" class="more-menu-item">
                         <i class="fas fa-briefcase"></i>
                         <span>Negocios</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="marketplace-social.html" class="more-menu-item">
                         <i class="fas fa-bullhorn"></i>
                         <span>Anuncios</span>
                     </a>
@@ -1946,10 +1946,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2094,7 +2094,7 @@
                     <h2 style="font-size:1rem;font-weight:600;color:#fff;margin:0;">
                         <i class="fas fa-trophy" style="color:#fbbf24;margin-right:8px;"></i>Logros de Creador
                     </h2>
-                    <a href="#" style="color:#00FFFF;font-size:0.85rem;text-decoration:none;">Ver todos</a>
+                    <a href="explorar.html" style="color:#00FFFF;font-size:0.85rem;text-decoration:none;">Ver todos</a>
                 </div>
                 <div id="achievementsContainer" style="display:flex;gap:12px;overflow-x:auto;padding-bottom:8px;">
                     <!-- Achievements loaded by JS -->
@@ -2187,7 +2187,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2324,12 +2324,10 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
-                <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/explorar.html
+++ b/explorar.html
@@ -1925,19 +1925,19 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="guardados.html" class="more-menu-item">
                         <i class="fas fa-list"></i>
                         <span>Listas</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="groups-advanced-system.html" class="more-menu-item">
                         <i class="fas fa-users"></i>
                         <span>Comunidades</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="trabajo.html" class="more-menu-item">
                         <i class="fas fa-briefcase"></i>
                         <span>Negocios</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="marketplace-social.html" class="more-menu-item">
                         <i class="fas fa-bullhorn"></i>
                         <span>Anuncios</span>
                     </a>
@@ -1946,10 +1946,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2048,7 +2048,7 @@
                     <h2 style="font-size:1.1rem;font-weight:600;color:#fff;margin:0;">
                         <i class="fas fa-newspaper" style="color:#00FFFF;margin-right:8px;"></i>Noticias Financieras
                     </h2>
-                    <a href="#" style="color:#00FFFF;font-size:0.85rem;text-decoration:none;">Ver más</a>
+                    <a href="explorar.html" style="color:#00FFFF;font-size:0.85rem;text-decoration:none;">Ver mas</a>
                 </div>
                 <div id="newsContainer" class="explore-news-list" style="display:flex;flex-direction:column;gap:12px;">
                     <!-- News items will be loaded here -->
@@ -2166,7 +2166,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2303,12 +2303,10 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
-                <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/gestionar.html
+++ b/gestionar.html
@@ -379,7 +379,7 @@
 
         // Alerts
         if (sp.pending > 0) {
-            html += '<div class="gm-alert gm-alert-warn"><i class="fas fa-exclamation-triangle"></i> ' + sp.pending + ' pago(s) pendiente(s) de verificacion — <a href="#" data-action="go-pagos-verificar" style="color:inherit;font-weight:600;">Verificar</a></div>';
+            html += '<div class="gm-alert gm-alert-warn"><i class="fas fa-exclamation-triangle"></i> ' + sp.pending + ' pago(s) pendiente(s) de verificacion — <button type="button" data-action="go-pagos-verificar" style="color:inherit;font-weight:600;background:none;border:0;padding:0;cursor:pointer;">Verificar</button></div>';
         }
 
         // Overview stats

--- a/governance.html
+++ b/governance.html
@@ -384,7 +384,7 @@
                         <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
                         <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
                         <div class="more-menu-divider"></div>
-                        <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                        <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                     </div>
                 </div>
             </nav>

--- a/groups-advanced-system.html
+++ b/groups-advanced-system.html
@@ -73,13 +73,13 @@
                 <div class="nav-menu-item nav-more-btn" id="navMoreBtn" data-action="toggle-more-menu" role="button" aria-expanded="false"><i class="fas fa-ellipsis-h"></i><span>Mas</span></div>
                 <div class="more-menu-dropdown" id="moreMenuDropdown" role="menu">
                     <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
+                    <a href="guardados.html" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
+                    <a href="groups-advanced-system.html" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
+                    <a href="trabajo.html" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
+                    <a href="marketplace-social.html" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
-                    <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                    <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                 </div>
                 </div>
             </nav>
@@ -1514,7 +1514,7 @@
             <a href="/mensajes.html" class="mobile-drawer-item"><i class="fas fa-envelope"></i><span>Mensajes</span></a>
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></a>
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item"><i class="fas fa-ticket-alt"></i><span>Loteria</span></a>
             <div class="mobile-drawer-divider"></div>
             <a href="/mi-perfil.html" class="mobile-drawer-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>

--- a/guardados.html
+++ b/guardados.html
@@ -1925,19 +1925,19 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="guardados.html" class="more-menu-item">
                         <i class="fas fa-list"></i>
                         <span>Listas</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="groups-advanced-system.html" class="more-menu-item">
                         <i class="fas fa-users"></i>
                         <span>Comunidades</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="trabajo.html" class="more-menu-item">
                         <i class="fas fa-briefcase"></i>
                         <span>Negocios</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="marketplace-social.html" class="more-menu-item">
                         <i class="fas fa-bullhorn"></i>
                         <span>Anuncios</span>
                     </a>
@@ -1946,10 +1946,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2119,7 +2119,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2256,12 +2256,10 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
-                <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/home-dashboard.html
+++ b/home-dashboard.html
@@ -1130,10 +1130,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuración</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesión</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -1330,10 +1330,10 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/index.html
+++ b/index.html
@@ -1768,10 +1768,10 @@
                 Únete a la comunidad de ahorro más grande de Honduras. 
                 Tu futuro financiero comienza aquí.
             </p>
-            <a href="javascript:void(0)" class="cta-btn" onclick="scrollToRegister()" role="button">
+            <button type="button" class="cta-btn" onclick="scrollToRegister()">
                 <i class="fas fa-rocket"></i>
                 Crear Cuenta Gratis
-            </a>
+            </button>
         </div>
     </section>
     

--- a/lottery-predictor.html
+++ b/lottery-predictor.html
@@ -1237,7 +1237,7 @@
             <div class="achievements-preview">
                 <div class="section-header">
                     <h3>🏅 Logros</h3>
-                    <a href="#" onclick="showAllAchievements(); return false;">Ver todos →</a>
+                    <button type="button" onclick="showAllAchievements(); return false;">Ver todos →</button>
                 </div>
                 <div class="achievements-grid" id="achievementsGrid">
                     <!-- Badges loaded dynamically -->
@@ -1248,7 +1248,7 @@
             <div class="mini-leaderboard">
                 <div class="section-header">
                     <h3>🏆 Ranking Semanal</h3>
-                    <a href="#" onclick="showFullLeaderboard(); return false;">Ver completo →</a>
+                    <button type="button" onclick="showFullLeaderboard(); return false;">Ver completo →</button>
                 </div>
                 <div class="leaderboard-list" id="leaderboardList">
                     <!-- Leaderboard loaded dynamically -->
@@ -1344,7 +1344,7 @@
         <div class="footer-disclaimer">
             ⚠️ <strong>Solo entretenimiento.</strong> Las predicciones no garantizan resultados.
             Juega responsablemente. +18 años.<br>
-            <a href="#" onclick="showDisclaimer(); return false;">Ver términos completos</a>
+            <button type="button" onclick="showDisclaimer(); return false;">Ver términos completos</button>
         </div>
     </main>
 

--- a/mensajes.html
+++ b/mensajes.html
@@ -1925,19 +1925,19 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="guardados.html" class="more-menu-item">
                         <i class="fas fa-list"></i>
                         <span>Listas</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="groups-advanced-system.html" class="more-menu-item">
                         <i class="fas fa-users"></i>
                         <span>Comunidades</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="trabajo.html" class="more-menu-item">
                         <i class="fas fa-briefcase"></i>
                         <span>Negocios</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="marketplace-social.html" class="more-menu-item">
                         <i class="fas fa-bullhorn"></i>
                         <span>Anuncios</span>
                     </a>
@@ -1946,10 +1946,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2106,7 +2106,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2243,14 +2243,14 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
-            <a href="#" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
+            </button>
+            <button type="button" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
                 <i class="fas fa-magic" style="color:#ffd700;"></i>
                 <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/mi-perfil.html
+++ b/mi-perfil.html
@@ -603,7 +603,7 @@
                                         var date = new Date(c.requested_at).toLocaleDateString('es-HN', { day:'numeric', month:'short', hour:'2-digit', minute:'2-digit' });
                                         return '<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid rgba(255,255,255,0.05);font-size:0.75rem;">' +
                                             '<div><span style="color:' + statusColor + ';font-weight:500;">' + c.status + '</span> <span style="color:var(--text-secondary);">' + date + '</span></div>' +
-                                            '<div style="font-weight:600;">' + parseFloat(c.amount_ltd).toFixed(2) + ' LTD' + (c.tx_hash ? ' <a href="#" title="' + _esc(c.tx_hash) + '" style="color:#00FFFF;font-size:0.65rem;" onclick="navigator.clipboard.writeText(this.dataset.hash);this.textContent=\'Copiado!\';return false;" data-hash="' + _esc(c.tx_hash) + '">TX</a>' : '') + '</div>' +
+                                            '<div style="font-weight:600;">' + parseFloat(c.amount_ltd).toFixed(2) + ' LTD' + (c.tx_hash ? ' <button type="button" title="' + _esc(c.tx_hash) + '" style="color:#00FFFF;font-size:0.65rem;background:none;border:0;padding:0;cursor:pointer;" onclick="navigator.clipboard.writeText(this.dataset.hash);this.textContent=\'Copiado!\';return false;" data-hash="' + _esc(c.tx_hash) + '">TX</button>' : '') + '</div>' +
                                         '</div>';
                                     }).join('');
                                 } catch(e) { div.innerHTML = '<div style="color:#f87171;">Error</div>'; }

--- a/mineria.html
+++ b/mineria.html
@@ -278,19 +278,19 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="guardados.html" class="more-menu-item">
                         <i class="fas fa-list"></i>
                         <span>Listas</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="groups-advanced-system.html" class="more-menu-item">
                         <i class="fas fa-users"></i>
                         <span>Comunidades</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="trabajo.html" class="more-menu-item">
                         <i class="fas fa-briefcase"></i>
                         <span>Negocios</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="marketplace-social.html" class="more-menu-item">
                         <i class="fas fa-bullhorn"></i>
                         <span>Anuncios</span>
                     </a>
@@ -299,10 +299,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>

--- a/my-tandas.html
+++ b/my-tandas.html
@@ -594,13 +594,13 @@
                 <div class="nav-menu-item nav-more-btn" id="navMoreBtn" data-action="toggle-more-menu" role="button" aria-expanded="false"><i class="fas fa-ellipsis-h"></i><span>Mas</span></div>
                 <div class="more-menu-dropdown" id="moreMenuDropdown" role="menu">
                     <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
+                    <a href="guardados.html" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
+                    <a href="groups-advanced-system.html" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
+                    <a href="trabajo.html" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
+                    <a href="marketplace-social.html" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
-                    <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                    <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                 </div>
                 </div>
             </nav>

--- a/my-wallet.html
+++ b/my-wallet.html
@@ -258,36 +258,36 @@
                             <h4>Settings del Wallet</h4>
                         </div>
                         <div class="dropdown-content">
-                            <a href="#" class="setting-item" onclick="toggleCurrencyPreference()">
+                            <button type="button" class="setting-item" onclick="toggleCurrencyPreference()">
                                 <i class="fas fa-dollar-sign"></i>
                                 <span>Moneda Principal</span>
                                 <span class="setting-value" id="currencyPreference">USD</span>
-                            </a>
-                            <a href="#" class="setting-item" onclick="toggleNotifications()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="toggleNotifications()">
                                 <i class="fas fa-bell"></i>
                                 <span>Notificaciones</span>
                                 <span class="setting-toggle" id="notificationToggle">ON</span>
-                            </a>
-                            <a href="#" class="setting-item" onclick="showSecuritySettings()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="showSecuritySettings()">
                                 <i class="fas fa-shield-alt"></i>
                                 <span>Security</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
-                            <a href="#" class="setting-item" onclick="showLightningWalletConfig()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="showLightningWalletConfig()">
                                 <i class="fas fa-bolt"></i>
                                 <span>Lightning Wallet</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
-                            <a href="#" class="setting-item" onclick="exportWalletData()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="exportWalletData()">
                                 <i class="fas fa-download"></i>
                                 <span>Exportar Datos</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
-                            <a href="#" class="setting-item" onclick="showPrivacySettings()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="showPrivacySettings()">
                                 <i class="fas fa-user-secret"></i>
                                 <span>Privacidad</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/perfil.html
+++ b/perfil.html
@@ -320,13 +320,13 @@
                 <div class="nav-menu-item nav-more-btn" id="navMoreBtn" data-action="toggle-more-menu" role="button" aria-expanded="false" aria-controls="moreMenuDropdown" aria-label="Mas opciones"><i class="fas fa-ellipsis-h"></i><span>Mas</span></div>
                 <div class="more-menu-dropdown" id="moreMenuDropdown" role="menu">
                     <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
+                    <a href="guardados.html" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
+                    <a href="groups-advanced-system.html" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
+                    <a href="trabajo.html" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
+                    <a href="marketplace-social.html" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
-                    <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                    <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                 </div>
                 </div>
             </nav>
@@ -366,7 +366,7 @@
             <a href="/mensajes.html" class="mobile-drawer-item"><i class="fas fa-envelope"></i><span>Mensajes</span></a>
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></a>
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item"><i class="fas fa-ticket-alt"></i><span>Loteria</span></a>
             <div class="mobile-drawer-divider"></div>
             <a href="/mi-perfil.html" class="mobile-drawer-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
@@ -445,8 +445,8 @@
     function parsePostContent(text) {
         if (!text) return '';
         var escaped = esc(text);
-        escaped = escaped.replace(/@([\w\-\.]+)/g, '<a href="#" class="pf-mention" data-handle="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">@$1</a>');
-        escaped = escaped.replace(/#([\wáéíóúñÁÉÍÓÚÑ]+)/g, '<a href="#" class="pf-hashtag" data-tag="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">#$1</a>');
+        escaped = escaped.replace(/@([\w\-\.]+)/g, '<a href="perfil.html?user=$1" class="pf-mention" data-handle="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">@$1</a>');
+        escaped = escaped.replace(/#([\wáéíóúñÁÉÍÓÚÑ]+)/g, '<a href="explorar.html?tag=$1" class="pf-hashtag" data-tag="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">#$1</a>');
         escaped = escaped.replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener" style="color:var(--ds-cyan,#00FFFF);text-decoration:underline;">$1</a>');
         return escaped;
     }

--- a/recompensas.html
+++ b/recompensas.html
@@ -327,7 +327,7 @@
             <a href="/mensajes.html" class="mobile-drawer-item"><i class="fas fa-envelope"></i><span>Mensajes</span></a>
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></a>
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item"><i class="fas fa-ticket-alt"></i><span>Loteria</span></a>
             <div class="mobile-drawer-divider"></div>
             <a href="/mi-perfil.html" class="mobile-drawer-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>

--- a/trabajo.html
+++ b/trabajo.html
@@ -1925,19 +1925,19 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="guardados.html" class="more-menu-item">
                         <i class="fas fa-list"></i>
                         <span>Listas</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="groups-advanced-system.html" class="more-menu-item">
                         <i class="fas fa-users"></i>
                         <span>Comunidades</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="trabajo.html" class="more-menu-item">
                         <i class="fas fa-briefcase"></i>
                         <span>Negocios</span>
                     </a>
-                    <a href="#" class="more-menu-item">
+                    <a href="marketplace-social.html" class="more-menu-item">
                         <i class="fas fa-bullhorn"></i>
                         <span>Anuncios</span>
                     </a>
@@ -1946,10 +1946,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2148,7 +2148,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2285,14 +2285,14 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
-            <a href="#" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
+            </button>
+            <button type="button" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
                 <i class="fas fa-magic" style="color:#ffd700;"></i>
                 <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/web3-dashboard.html
+++ b/web3-dashboard.html
@@ -173,45 +173,45 @@
                             </div>
                             
                             <div class="profile-menu-items">
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openProfile()">
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openProfile()">
                                     <i class="fas fa-user"></i>
                                     <span>My Profile</span>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openWalletDetails()">
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openWalletDetails()">
                                     <i class="fas fa-wallet"></i>
                                     <span>Wallet Details</span>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openTransactionHistory()">
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openTransactionHistory()">
                                     <i class="fas fa-history"></i>
                                     <span>Transaction History</span>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openSettings()">
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openSettings()">
                                     <i class="fas fa-cog"></i>
                                     <span>Settings</span>
-                                </a>
+                                </button>
                                 <div class="profile-menu-divider"></div>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.toggleTheme()">
+                                <button type="button" class="profile-menu-item" onclick="dashboard.toggleTheme()">
                                     <i class="fas fa-moon" id="themeToggleIcon"></i>
                                     <span>Dark Mode</span>
                                     <div class="theme-toggle">
                                         <input type="checkbox" id="themeCheckbox" checked>
                                         <label for="themeCheckbox" class="toggle-slider"></label>
                                     </div>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openLanguageSelector()">
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openLanguageSelector()">
                                     <i class="fas fa-globe"></i>
                                     <span>Language</span>
                                     <span class="language-current">EN</span>
-                                </a>
+                                </button>
                                 <div class="profile-menu-divider"></div>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openSupport()">
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openSupport()">
                                     <i class="fas fa-question-circle"></i>
                                     <span>Help & Support</span>
-                                </a>
-                                <a href="#" class="profile-menu-item disconnect" onclick="laTandaEcosystem?.handleWalletConnect()" id="disconnectWalletBtn" style="display: none;">
+                                </button>
+                                <button type="button" class="profile-menu-item disconnect" onclick="laTandaEcosystem?.handleWalletConnect()" id="disconnectWalletBtn" style="display: none;">
                                     <i class="fas fa-sign-out-alt"></i>
                                     <span>Disconnect Wallet</span>
-                                </a>
+                                </button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Closes #155.

## What changed
- Replaced empty `href="#"` menu destinations with real local page links.
- Converted action-only anchors to `<button type="button">` controls, including logout, MIA drawer, wallet/settings actions, modal actions, and copy-to-clipboard actions.
- Replaced the `javascript:void(0)` CTA with a button that keeps the existing `scrollToRegister()` behavior.
- Updated generated mention/hashtag links to point to profile/explore URLs instead of empty anchors.

## Verification
- Root HTML files found: 55.
- Five examples: `index.html`, `auth-enhanced.html`, `creator-hub.html`, `my-wallet.html`, `web3-dashboard.html`.
- Click-action pattern used by the platform: `<button data-action>` for delegated click actions.
- `rg 'href="#"|href="javascript:void\(0\)"' --glob '*.html'` returns no matches.
- `git diff --check` passes.
- A tag-balance scan found no mismatched `<a>` or `<button>` counts in root HTML files.