### PR TITLE
feat: add persistent dark/light theme toggle

### DIFF
--- a/css/dashboard-layout.css
+++ b/css/dashboard-layout.css
@@ -4,6 +4,96 @@
  * Version: 1.0.0
  * Added: 2026-01-25
  */
+:root {
+ --bg-primary: #0f172a;
+ --bg-secondary: #111827;
+ --bg-card: #0d1117;
+ --bg-elevated: rgba(255, 255, 255, 0.05);
+ --text-primary: #f8fafc;
+ --text-secondary: #94a3b8;
+ --text-muted: #64748b;
+ --border-card: #ffffff10;
+ --border-accent: #00ffff33;
+ --tanda-cyan: #00ffff;
+ --crypto-gold: #ffd700;
+ color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+ --bg-primary: #f8fafc;
+ --bg-secondary: #eef2f7;
+ --bg-card: #ffffff;
+ --bg-elevated: rgba(15, 23, 42, 0.04);
+ --text-primary: #0f172a;
+ --text-secondary: #475569;
+ --text-muted: #64748b;
+ --border-card: rgba(15, 23, 42, 0.12);
+ --border-accent: rgba(8, 145, 178, 0.32);
+ --tanda-cyan: #0891b2;
+ --crypto-gold: #b45309;
+ --ds-bg-base: #f8fafc;
+ --ds-bg-surface: rgba(15, 23, 42, 0.04);
+ --ds-bg-surface-hover: rgba(15, 23, 42, 0.08);
+ --ds-bg-elevated: #ffffff;
+ --ds-bg-overlay: rgba(15, 23, 42, 0.35);
+ --ds-text-primary: #0f172a;
+ --ds-text-secondary: #334155;
+ --ds-text-muted: #64748b;
+ --ds-border: rgba(15, 23, 42, 0.1);
+ --ds-border-hover: rgba(15, 23, 42, 0.18);
+ --ds-border-accent: rgba(8, 145, 178, 0.35);
+ --ds-glass-bg: rgba(255, 255, 255, 0.82);
+ --ds-glass-border: rgba(15, 23, 42, 0.1);
+ color-scheme: light;
+}
+
+:root[data-theme="light"] body,
+body[data-theme="light"] {
+ background: var(--bg-primary);
+ color: var(--text-primary);
+}
+
+:root[data-theme="light"] .dashboard-3col {
+ background: var(--bg-primary);
+}
+
+:root[data-theme="light"] .left-sidebar,
+:root[data-theme="light"] .right-sidebar,
+:root[data-theme="light"] .right-sidebar-sticky {
+ color: var(--text-primary);
+}
+
+:root[data-theme="light"] .main-feed {
+ border-left-color: var(--border-card);
+ border-right-color: var(--border-card);
+}
+
+:root[data-theme="light"] .main-feed-header,
+:root[data-theme="light"] .sidebar-hub-card,
+:root[data-theme="light"] .sidebar-widget {
+ background: rgba(255, 255, 255, 0.86);
+ border-color: var(--border-card);
+ color: var(--text-primary);
+}
+
+:root[data-theme="light"] .main-feed-title,
+:root[data-theme="light"] .nav-menu-item.active,
+:root[data-theme="light"] .sidebar-hub-card-value {
+ color: var(--text-primary);
+}
+
+:root[data-theme="light"] .nav-menu-item,
+:root[data-theme="light"] .nav-section-label,
+:root[data-theme="light"] .sidebar-hub-card-title,
+:root[data-theme="light"] .sidebar-hub-card-label,
+:root[data-theme="light"] .sidebar-hub-card-meta {
+ color: var(--text-secondary);
+}
+
+:root[data-theme="light"] .nav-menu-item:hover {
+ background: rgba(8, 145, 178, 0.08);
+}
+
 /* ================================================
  MAIN LAYOUT CONTAINER
  ================================================ */
@@ -119,6 +209,41 @@
  transform: scale(1.02);
  box-shadow: 0 4px 20px rgba(0, 255, 255, 0.4);
 }
+.theme-toggle-btn {
+ width: 100%;
+ border: 0;
+ background: transparent;
+ cursor: pointer;
+ font-family: inherit;
+ text-align: left;
+}
+
+.theme-toggle-btn.nav-item {
+ margin-top: 8px;
+ color: var(--text-secondary, rgba(255, 255, 255, 0.85));
+}
+
+.theme-toggle-btn .theme-badge {
+ margin-left: auto;
+ background: linear-gradient(135deg, var(--tanda-cyan, #00ffff), var(--crypto-gold, #ffd700));
+}
+
+.theme-toggle-btn[aria-pressed="true"] .theme-badge {
+ background: linear-gradient(135deg, #f59e0b, #facc15);
+ color: #0f172a;
+}
+
+.mobile-drawer-item.theme-toggle-btn {
+ appearance: none;
+ border: 0;
+ background: transparent;
+ width: 100%;
+}
+
+:root[data-theme="light"] .theme-toggle-btn:hover {
+ background: rgba(8, 145, 178, 0.08);
+}
+
 .nav-section-divider {
  height: 1px;
  background: rgba(255, 255, 255, 0.08);

--- a/js/components-loader.js
+++ b/js/components-loader.js
@@ -1,5 +1,44 @@
 // Phase 0: Load helpers + iOS PWA prompt (i18n removed — platform uses Spanish)
 (function(){
+  var key = "theme_preference";
+  function getStoredTheme() {
+    try {
+      var value = localStorage.getItem(key);
+      return value === "light" || value === "dark" ? value : "dark";
+    } catch (e) {
+      return "dark";
+    }
+  }
+  function applyTheme(theme) {
+    var safeTheme = theme === "light" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", safeTheme);
+    document.documentElement.style.colorScheme = safeTheme;
+    if (document.body) {
+      document.body.setAttribute("data-theme", safeTheme);
+    }
+  }
+  applyTheme(getStoredTheme());
+  document.addEventListener("DOMContentLoaded", function() {
+    applyTheme(getStoredTheme());
+  });
+  window.LaTandaTheme = {
+    key: key,
+    get: getStoredTheme,
+    apply: applyTheme,
+    set: function(theme) {
+      var safeTheme = theme === "light" ? "light" : "dark";
+      try {
+        localStorage.setItem(key, safeTheme);
+      } catch (e) {}
+      applyTheme(safeTheme);
+      document.dispatchEvent(new CustomEvent("themeChanged", { detail: { theme: safeTheme } }));
+    },
+    toggle: function() {
+      this.set(this.get() === "light" ? "dark" : "light");
+    }
+  };
+})();
+(function(){
   var scripts = [
     'js/helpers/locale-helpers.js?v=1.0',
     'js/helpers/fetch-retry.js?v=1.0',
@@ -202,3 +241,84 @@ document.addEventListener('DOMContentLoaded', function() {
         LaTandaComponentLoader.loadMobileDrawer();
     }, 500);
 });
+
+(function() {
+    function updateThemeToggle(button) {
+        if (!button || !window.LaTandaTheme) return;
+        var theme = window.LaTandaTheme.get();
+        var isLight = theme === 'light';
+        button.setAttribute('aria-pressed', String(isLight));
+        button.setAttribute('title', isLight ? 'Cambiar a tema oscuro' : 'Cambiar a tema claro');
+        var icon = button.querySelector('i');
+        var text = button.querySelector('.nav-text, .mobile-drawer-text');
+        var badge = button.querySelector('.theme-badge');
+        if (icon) icon.className = (isLight ? 'fas fa-sun' : 'fas fa-moon') + ' nav-icon';
+        if (text) text.textContent = isLight ? 'Tema claro' : 'Tema oscuro';
+        if (badge) badge.textContent = isLight ? 'LIGHT' : 'DARK';
+    }
+
+    function wireButton(button) {
+        if (!button || button.dataset.themeToggleWired === 'true') return;
+        button.dataset.themeToggleWired = 'true';
+        button.addEventListener('click', function(event) {
+            event.preventDefault();
+            if (window.LaTandaTheme) {
+                window.LaTandaTheme.toggle();
+            }
+        });
+        updateThemeToggle(button);
+    }
+
+    function createSidebarToggle() {
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.id = 'themeToggleBtn';
+        button.className = 'nav-item theme-toggle-btn';
+        button.innerHTML = '<i class="fas fa-moon nav-icon"></i><span class="nav-text">Tema oscuro</span><span class="nav-badge theme-badge">DARK</span>';
+        return button;
+    }
+
+    function createDrawerToggle() {
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.id = 'mobileThemeToggleBtn';
+        button.className = 'mobile-drawer-item theme-toggle-btn';
+        button.innerHTML = '<i class="fas fa-moon nav-icon"></i><span class="mobile-drawer-text">Tema oscuro</span><span class="nav-badge theme-badge">DARK</span>';
+        return button;
+    }
+
+    function ensureThemeToggles() {
+        var sidebar = document.getElementById('sidebar');
+        if (sidebar && !document.getElementById('themeToggleBtn')) {
+            var accountSection = sidebar.querySelector('.nav-section:last-of-type');
+            var footer = sidebar.querySelector('.sidebar-footer');
+            var toggle = createSidebarToggle();
+            if (accountSection) {
+                accountSection.appendChild(toggle);
+            } else if (footer) {
+                sidebar.insertBefore(toggle, footer);
+            } else {
+                sidebar.appendChild(toggle);
+            }
+            wireButton(toggle);
+        }
+
+        var drawerNav = document.querySelector('#mobileDrawer .mobile-drawer-nav');
+        if (drawerNav && !document.getElementById('mobileThemeToggleBtn')) {
+            var drawerToggle = createDrawerToggle();
+            drawerNav.insertBefore(drawerToggle, drawerNav.firstChild);
+            wireButton(drawerToggle);
+        }
+
+        document.querySelectorAll('.theme-toggle-btn').forEach(updateThemeToggle);
+    }
+
+    document.addEventListener('sidebarLoaded', ensureThemeToggles);
+    document.addEventListener('themeChanged', function() {
+        document.querySelectorAll('.theme-toggle-btn').forEach(updateThemeToggle);
+    });
+    document.addEventListener('DOMContentLoaded', function() {
+        ensureThemeToggles();
+        setTimeout(ensureThemeToggles, 700);
+    });
+})();


### PR DESCRIPTION
## Issue
Resolves #84

## Summary
- Add an early `theme_preference` loader in `js/components-loader.js` so the saved theme is applied before the shared components finish loading.
- Add a sidebar and mobile drawer theme toggle wired to `localStorage` with key `theme_preference`.
- Add light theme CSS variable overrides in `css/dashboard-layout.css` for hub layouts, sidebars, cards, text, borders, and navigation hover states.
- Keep the implementation inside the requested files; no standalone theme JS/CSS files were added.

## Verification
- `node --check js/components-loader.js`
- `git diff --check`

## Bounty / payout
Bounty issue: #84
Preferred payout: PayPal https://paypal.me/Jeremytsangchina
Backup payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`