### PR TITLE
Add content report flow for social feed posts

### DIFF
--- a/api-proxy-enhanced.js
+++ b/api-proxy-enhanced.js
@@ -126,6 +126,10 @@ class EnhancedAPIProxy {
 
         // Parse user ID from token or default
         const userId = this.extractUserIdFromAuth(options) || 'admin_001';
+        const socialReportMatch = baseEndpoint.match(/^\/api\/feed\/social\/([^/]+)\/report$/);
+        if (method === 'POST' && socialReportMatch) {
+            return this.handleSocialReport(socialReportMatch[1], userId, options);
+        }
         
         // FORCE: Skip missingHandlers for /groups - go directly to switch statement
         console.log(`🔍 ENDPOINT CHECK: ${baseEndpoint} - bypassing missingHandlers for /groups`);
@@ -1524,6 +1528,65 @@ class EnhancedAPIProxy {
                 note: "This endpoint is simulated and will be implemented in production"
             },
             meta: this.createMeta()
+        };
+    }
+
+    handleSocialReport(eventId, userId, options = {}) {
+        const allowedReasons = ['spam', 'harassment', 'misinformation', 'inappropriate', 'other'];
+        let body = {};
+        try {
+            body = typeof options.body === 'string' ? JSON.parse(options.body || '{}') : (options.body || {});
+        } catch (error) {
+            body = {};
+        }
+
+        const reason = String(body.reason || '').trim();
+        const description = String(body.description || '').trim();
+
+        if (!eventId) {
+            return { success: false, message: 'Publicacion no encontrada', status: 404 };
+        }
+
+        if (!allowedReasons.includes(reason)) {
+            return { success: false, message: 'Motivo invalido', status: 400 };
+        }
+
+        if (description.length > 500) {
+            return { success: false, message: 'La descripcion no puede exceder 500 caracteres', status: 400 };
+        }
+
+        const storageKey = 'latanda_social_reports';
+        let reports = [];
+        try {
+            reports = JSON.parse(localStorage.getItem(storageKey) || '[]');
+        } catch (error) {
+            reports = [];
+        }
+
+        const duplicate = reports.some(report =>
+            String(report.event_id) === String(eventId) && String(report.reporter_id) === String(userId)
+        );
+        if (duplicate) {
+            return { success: false, message: 'Ya reportaste esta publicacion', status: 409 };
+        }
+
+        const report = {
+            id: 'report_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8),
+            reporter_id: userId,
+            event_id: eventId,
+            reason,
+            description,
+            status: 'open',
+            created_at: new Date().toISOString()
+        };
+
+        reports.push(report);
+        localStorage.setItem(storageKey, JSON.stringify(reports));
+
+        return {
+            success: true,
+            message: 'Reporte recibido',
+            data: { report }
         };
     }
 }

--- a/css/hub/social-feed.css
+++ b/css/hub/social-feed.css
@@ -291,6 +291,135 @@
 .engagement-btn.reposted i {
  font-weight: 900;
 }
+.engagement-btn.report-btn:hover {
+ color: #f87171;
+}
+.sf-report-modal {
+ position: fixed;
+ inset: 0;
+ z-index: 10050;
+ display: flex;
+ align-items: center;
+ justify-content: center;
+ padding: 16px;
+ opacity: 0;
+ pointer-events: none;
+ transition: opacity 0.18s ease;
+}
+.sf-report-modal.active {
+ opacity: 1;
+ pointer-events: auto;
+}
+.sf-report-backdrop {
+ position: absolute;
+ inset: 0;
+ background: rgba(2, 6, 23, 0.72);
+ -webkit-backdrop-filter: blur(8px);
+ backdrop-filter: blur(8px);
+}
+.sf-report-dialog {
+ position: relative;
+ width: min(440px, 100%);
+ background: #111827;
+ border: 1px solid rgba(255, 255, 255, 0.12);
+ border-radius: 14px;
+ padding: 18px;
+ box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+ color: #f8fafc;
+ transform: translateY(10px) scale(0.98);
+ transition: transform 0.18s ease;
+}
+.sf-report-modal.active .sf-report-dialog {
+ transform: translateY(0) scale(1);
+}
+.sf-report-header {
+ display: flex;
+ align-items: flex-start;
+ justify-content: space-between;
+ gap: 12px;
+ margin-bottom: 16px;
+}
+.sf-report-header h3 {
+ margin: 0 0 4px;
+ font-size: 1.05rem;
+ font-weight: 700;
+}
+.sf-report-header p {
+ margin: 0;
+ color: rgba(255, 255, 255, 0.62);
+ font-size: 0.9rem;
+}
+.sf-report-close {
+ width: 34px;
+ height: 34px;
+ display: grid;
+ place-items: center;
+ border: 0;
+ border-radius: 8px;
+ background: rgba(255, 255, 255, 0.08);
+ color: rgba(255, 255, 255, 0.75);
+ cursor: pointer;
+}
+.sf-report-label {
+ display: block;
+ margin: 12px 0 6px;
+ color: rgba(255, 255, 255, 0.78);
+ font-size: 0.86rem;
+ font-weight: 600;
+}
+.sf-report-dialog select,
+.sf-report-dialog textarea {
+ width: 100%;
+ border: 1px solid rgba(255, 255, 255, 0.14);
+ border-radius: 10px;
+ background: rgba(15, 23, 42, 0.9);
+ color: #f8fafc;
+ font: inherit;
+ padding: 11px 12px;
+ outline: none;
+}
+.sf-report-dialog textarea {
+ resize: vertical;
+ min-height: 96px;
+ max-height: 180px;
+}
+.sf-report-dialog select:focus,
+.sf-report-dialog textarea:focus {
+ border-color: #00ffff;
+ box-shadow: 0 0 0 3px rgba(0, 255, 255, 0.12);
+}
+.sf-report-meta {
+ margin-top: 6px;
+ text-align: right;
+ color: rgba(255, 255, 255, 0.48);
+ font-size: 0.78rem;
+}
+.sf-report-actions {
+ display: flex;
+ justify-content: flex-end;
+ gap: 10px;
+ margin-top: 16px;
+}
+.sf-report-cancel,
+.sf-report-submit {
+ border: 0;
+ border-radius: 10px;
+ padding: 10px 14px;
+ font-weight: 700;
+ cursor: pointer;
+}
+.sf-report-cancel {
+ background: rgba(255, 255, 255, 0.08);
+ color: rgba(255, 255, 255, 0.78);
+}
+.sf-report-submit {
+ background: #ef4444;
+ color: #fff;
+}
+.sf-report-submit:disabled {
+ opacity: 0.65;
+ cursor: wait;
+}
 .repost-menu-popup {
  background: rgba(15, 23, 42, 0.95);
  border: 1px solid rgba(255, 255, 255, 0.12);

--- a/js/hub/social-feed.js
+++ b/js/hub/social-feed.js
@@ -15,3 +15,107 @@ inp.parentNode!==btn&&btn.appendChild(inp);
 },1500);
 });
 })();
+
+// v4.25.13: content report/flag flow for social feed posts
+(function(){
+var feed=window.SocialFeed||("undefined"!==typeof SocialFeed?SocialFeed:null);
+if(!feed||feed.__reportFlowPatched)return;
+window.SocialFeed=feed;
+feed.__reportFlowPatched=!0;
+var reasons=["spam","harassment","misinformation","inappropriate","other"];
+var labels={spam:"Spam o publicidad",harassment:"Acoso o abuso",misinformation:"Informacion falsa",inappropriate:"Contenido inapropiado",other:"Otro"};
+function reportButton(id){
+ return '<button class="engagement-btn report-btn" data-action="sf-report-post" data-event-id="'+feed.escapeHtml(String(id))+'" title="Reportar"><i class="far fa-flag"></i></button>';
+}
+function injectReportButton(html,id){
+ if(!html||html.indexOf(" report-btn")!==-1)return html;
+ return html.replace(/(<button class="engagement-btn bookmark-btn[\s\S]*?<\/button>)/, "$1"+reportButton(id));
+}
+var originalRenderEventCard=feed.renderEventCard;
+if("function"===typeof originalRenderEventCard){
+ feed.renderEventCard=function(event){
+  var html=originalRenderEventCard.call(this,event);
+  return injectReportButton(html,event&&event.id);
+ };
+}
+var originalRenderPostDetail=feed._renderPostDetail;
+if("function"===typeof originalRenderPostDetail){
+ feed._renderPostDetail=function(post,comments,total){
+  originalRenderPostDetail.call(this,post,comments,total);
+  var bar=document.querySelector("#postDetailOverlay .pd-engagement-bar");
+  if(!bar||bar.querySelector(".report-btn")||!post)return;
+  var bookmark=bar.querySelector(".bookmark-btn");
+  if(bookmark)bookmark.insertAdjacentHTML("afterend",reportButton(post.id));
+ };
+}
+feed.openReportModal=function(eventId){
+ if(!eventId)return;
+ var existing=document.getElementById("sfReportModal");
+ existing&&existing.remove();
+ var modal=document.createElement("div");
+ modal.id="sfReportModal";
+ modal.className="sf-report-modal";
+ modal.innerHTML='<div class="sf-report-backdrop" data-action="sf-report-close"></div><form class="sf-report-dialog" id="sfReportForm"><div class="sf-report-header"><div><h3>Reportar publicacion</h3><p>Ayudanos a mantener segura la comunidad.</p></div><button type="button" class="sf-report-close" data-action="sf-report-close" aria-label="Cerrar"><i class="fas fa-times"></i></button></div><input type="hidden" name="event_id" value="'+this.escapeHtml(String(eventId))+'"><label class="sf-report-label" for="sfReportReason">Motivo</label><select id="sfReportReason" name="reason" required>'+reasons.map(function(reason){return'<option value="'+reason+'">'+labels[reason]+"</option>"}).join("")+'</select><label class="sf-report-label" for="sfReportDescription">Descripcion opcional</label><textarea id="sfReportDescription" name="description" maxlength="500" rows="4" placeholder="Agrega contexto para el equipo de moderacion"></textarea><div class="sf-report-meta"><span id="sfReportCount">0</span>/500</div><div class="sf-report-actions"><button type="button" class="sf-report-cancel" data-action="sf-report-close">Cancelar</button><button type="submit" class="sf-report-submit">Enviar reporte</button></div></form>';
+ document.body.appendChild(modal);
+ document.body.style.overflow="hidden";
+ var textarea=modal.querySelector("#sfReportDescription");
+ var count=modal.querySelector("#sfReportCount");
+ textarea&&textarea.addEventListener("input",function(){count&&(count.textContent=String(textarea.value.length))});
+ modal.querySelector("#sfReportForm").addEventListener("submit",this.submitReport.bind(this));
+ setTimeout(function(){modal.classList.add("active")},0);
+};
+feed.closeReportModal=function(){
+ var modal=document.getElementById("sfReportModal");
+ if(!modal)return;
+ modal.classList.remove("active");
+ document.body.style.overflow="";
+ setTimeout(function(){modal.remove()},180);
+};
+feed.submitReport=async function(event){
+ event.preventDefault();
+ var form=event.currentTarget;
+ var token=localStorage.getItem("auth_token")||localStorage.getItem("authToken");
+ if(!token){window.LaTandaPopup&&window.LaTandaPopup.showError("Inicia sesion para reportar");return}
+ var eventId=form.event_id.value;
+ var reason=form.reason.value;
+ var description=(form.description.value||"").trim();
+ if(reasons.indexOf(reason)===-1){window.LaTandaPopup&&window.LaTandaPopup.showWarning("Selecciona un motivo valido");return}
+ if(description.length>500){window.LaTandaPopup&&window.LaTandaPopup.showWarning("La descripcion no puede exceder 500 caracteres");return}
+ var submit=form.querySelector(".sf-report-submit");
+ submit&&(submit.disabled=!0,submit.textContent="Enviando...");
+ try{
+  var response=await fetch("/api/feed/social/"+encodeURIComponent(eventId)+"/report",{method:"POST",headers:{"Content-Type":"application/json",Authorization:"Bearer "+token},body:JSON.stringify({reason:reason,description:description})});
+  var data=await response.json().catch(function(){return{}});
+  if(response.status===409){window.LaTandaPopup&&window.LaTandaPopup.showWarning(data.message||"Ya reportaste esta publicacion");return}
+  if(!response.ok||!data.success){
+   if(window.apiProxy&&"function"===typeof window.apiProxy.makeRequest){
+    data=await window.apiProxy.makeRequest("/api/feed/social/"+encodeURIComponent(eventId)+"/report",{method:"POST",body:{reason:reason,description:description},headers:{Authorization:"Bearer "+token}});
+   }
+  }
+  if(!data.success)throw new Error(data.message||"No se pudo enviar el reporte");
+  this.closeReportModal();
+  window.LaTandaPopup&&window.LaTandaPopup.showSuccess("Reporte enviado. Gracias por ayudarnos.");
+ }catch(err){
+  window.LaTandaPopup&&window.LaTandaPopup.showError(err.message||"Error al enviar reporte");
+ }finally{
+  submit&&(submit.disabled=!1,submit.textContent="Enviar reporte");
+ }
+};
+document.addEventListener("click",function(event){
+ var close=event.target.closest('[data-action="sf-report-close"]');
+ if(close){event.preventDefault();window.SocialFeed.closeReportModal();return}
+ var report=event.target.closest('[data-action="sf-report-post"],.report-btn');
+ if(!report)return;
+ var eventId=report.dataset.eventId||report.dataset.id;
+ if(!eventId)return;
+ event.preventDefault();
+ event.stopPropagation();
+ event.stopImmediatePropagation&&event.stopImmediatePropagation();
+ var popup=report.closest(".sf-more-popup");
+ popup&&popup.remove();
+ window.SocialFeed.openReportModal(eventId);
+},true);
+document.addEventListener("keydown",function(event){
+ if("Escape"===event.key&&document.getElementById("sfReportModal"))window.SocialFeed.closeReportModal();
+});
+})();


### PR DESCRIPTION
Fixes #51

## Summary
- Adds a report button immediately after the bookmark action in social feed cards and post detail view.
- Adds a Spanish report modal with reason dropdown, optional 500-character description, auth validation, duplicate handling, and submission to `POST /api/feed/social/:id/report`.
- Adds simulated API proxy support for local/dev flows, including allowed reasons, per-user/per-post duplicate prevention, and localStorage persistence.
- Adds responsive modal styling in `css/hub/social-feed.css`.

## Codebase verification
- `renderEventCard()` renders the existing engagement bar with like, comment, share, repost, bookmark, and more actions.
- Existing actions use class-based handlers and `data-id`; the three-dot menu already had `data-action="sf-report-post"` but it only displayed a notification. This PR intercepts that action and opens the new report flow.
- The issue mentioned `integrated-api-complete-95-endpoints.js`, but that file is not present in this repository. The local simulated endpoint was added to `api-proxy-enhanced.js`, which is the available API proxy implementation.

## Suggested SQL migration
```sql
CREATE TABLE social_reports (
    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
    reporter_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
    event_id UUID NOT NULL REFERENCES social_events(id) ON DELETE CASCADE,
    reason VARCHAR(32) NOT NULL CHECK (reason IN ('spam', 'harassment', 'misinformation', 'inappropriate', 'other')),
    description TEXT CHECK (description IS NULL OR char_length(description) <= 500),
    status VARCHAR(16) NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'reviewed', 'dismissed')),
    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    UNIQUE (reporter_id, event_id)
);

CREATE INDEX idx_social_reports_event_id ON social_reports(event_id);
CREATE INDEX idx_social_reports_status_created_at ON social_reports(status, created_at DESC);
```

## Verification
- `node --check js/hub/social-feed.js`
- `node --check api-proxy-enhanced.js`
- `git diff --check`