### PR TITLE
Add validator monitoring stack

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,120 @@
+# La Tanda Validator Monitoring
+
+This directory contains a self-contained Prometheus, Alertmanager, Grafana, and node_exporter stack for La Tanda Chain validators.
+
+## Requirements
+
+- Ubuntu 22.04 or newer
+- Docker Engine 24+
+- Docker Compose v2
+- Open inbound access to Grafana only if you intend to expose it publicly
+- La Tanda node metrics enabled on `:26660`
+- Cosmos SDK REST metrics available on `:1317/metrics`
+
+## Quick Start
+
+1. Copy the environment template:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Edit `.env` and set:
+
+   - `GRAFANA_ADMIN_PASSWORD`
+   - `ALERT_WEBHOOK_URL`
+
+3. Add validator metrics targets:
+
+   ```bash
+   nano prometheus/targets/validators.yml
+   nano prometheus/targets/rest-api.yml
+   ```
+
+4. Start the stack:
+
+   ```bash
+   docker compose up -d
+   ```
+
+5. Open Grafana:
+
+   ```text
+   http://SERVER_IP:3000
+   ```
+
+Dashboards are provisioned automatically under the `La Tanda Chain` folder. Prometheus keeps at least 30 days of local time series data.
+
+## Services
+
+| Service | Port | Purpose |
+| --- | --- | --- |
+| Grafana | `3000` | Dashboards and visual review |
+| Prometheus | `9090` | Metrics scraping and alert evaluation |
+| Alertmanager | `9093` | Alert grouping and webhook routing |
+| node_exporter | `9100` | Host CPU, memory, disk, and network metrics |
+
+## Target Configuration
+
+Prometheus uses file service discovery so operators can update targets without editing the main Prometheus config.
+
+Example `prometheus/targets/validators.yml`:
+
+```yaml
+- labels:
+    validator: genesis
+    network: latanda-testnet
+  targets:
+    - 10.0.0.10:26660
+```
+
+Example `prometheus/targets/rest-api.yml`:
+
+```yaml
+- labels:
+    validator: genesis
+    network: latanda-testnet
+  targets:
+    - 10.0.0.10:1317
+```
+
+After changing target files, reload Prometheus:
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+## Dashboards
+
+- **Validator Overview**: voting power, jail status, missed blocks, uptime, and peer count.
+- **Block Production**: latest height, block interval, height progression, and produced block indicators.
+- **Network Health**: validator count, bonded stake, active governance proposal indicators, and network availability.
+- **Node Performance**: CPU, memory, disk, and network I/O from node_exporter.
+
+## Alert Routing
+
+Alertmanager sends all alerts to `ALERT_WEBHOOK_URL`. Critical alerts repeat every 30 minutes until resolved; non-critical alerts repeat every 4 hours.
+
+If the webhook points to Discord, use a bridge that accepts Alertmanager webhook payloads or a webhook transformer. Alertmanager sends generic JSON, not Discord's native message shape.
+
+## Operations
+
+View running services:
+
+```bash
+docker compose ps
+```
+
+Tail logs:
+
+```bash
+docker compose logs -f prometheus alertmanager grafana
+```
+
+Upgrade safely:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+

--- a/monitoring/VALIDATOR_GUIDE.md
+++ b/monitoring/VALIDATOR_GUIDE.md
@@ -1,0 +1,101 @@
+# Validator Onboarding Guide
+
+This guide helps a La Tanda validator run the monitoring stack next to a node.
+
+## Enable Tendermint Metrics
+
+In the validator node `config.toml`, enable Prometheus metrics:
+
+```toml
+prometheus = true
+prometheus_listen_addr = ":26660"
+```
+
+Restart the node after changing the config.
+
+## Enable Cosmos REST Metrics
+
+Expose the Cosmos REST service with metrics enabled. The stack expects metrics at:
+
+```text
+http://NODE_HOST:1317/metrics
+```
+
+Keep this endpoint private to the monitoring host when possible.
+
+## Add Your Validator
+
+Edit `prometheus/targets/validators.yml`:
+
+```yaml
+- labels:
+    validator: your-validator-name
+    network: latanda-testnet
+  targets:
+    - your-node-private-ip:26660
+```
+
+Edit `prometheus/targets/rest-api.yml`:
+
+```yaml
+- labels:
+    validator: your-validator-name
+    network: latanda-testnet
+  targets:
+    - your-node-private-ip:1317
+```
+
+Reload Prometheus:
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+## Alert Rules
+
+### ValidatorJailed
+
+Severity: critical
+
+Fires when staking metrics report the validator as jailed. This should page the operator immediately.
+
+### MissedBlocksCritical
+
+Severity: critical
+
+Fires when missed blocks exceed 4,000, which is 40% of the current `signed_blocks_window` value of 10,000. The chain uses `min_signed_per_window = 0.500000000000000000`, so validators are at jail risk after more than 5,000 missed blocks in the window.
+
+### MissedBlocksWarning
+
+Severity: warning
+
+Fires when missed blocks exceed 2,000, which is 20% of the current `signed_blocks_window` value of 10,000. Check peer count, disk latency, process restarts, and validator logs.
+
+### LowPeerCount
+
+Severity: warning
+
+Fires when CometBFT reports fewer than 3 peers for 10 minutes.
+
+### ActiveGovernanceProposal
+
+Severity: info
+
+Fires when a new active governance proposal is detected, so the operator can review and vote.
+
+## Security Notes
+
+- Do not expose Prometheus or Alertmanager publicly without authentication.
+- Put Grafana behind HTTPS if it is reachable from the internet.
+- Use a strong `GRAFANA_ADMIN_PASSWORD`.
+- Prefer private IPs or VPN addresses for validator targets.
+
+## Troubleshooting
+
+If dashboards are empty:
+
+1. Check Prometheus targets at `http://SERVER_IP:9090/targets`.
+2. Confirm the validator exposes `http://NODE_IP:26660/metrics`.
+3. Confirm REST metrics expose `http://NODE_IP:1317/metrics`.
+4. Check labels in the target files.
+5. Restart Grafana if provisioning files were edited while it was running.

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,23 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: webhook
+  group_by:
+    - alertname
+    - validator
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity="critical"
+      repeat_interval: 30m
+      receiver: webhook
+
+receivers:
+  - name: webhook
+    webhook_configs:
+      - url: '${ALERT_WEBHOOK_URL}'
+        send_resolved: true
+

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.53.4
+    container_name: latanda-prometheus
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=30d
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - prometheus-data:/prometheus
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - ./prometheus/targets:/etc/prometheus/targets:ro
+    depends_on:
+      - alertmanager
+      - node-exporter
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: latanda-alertmanager
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --config.expand-env
+      - --storage.path=/alertmanager
+    environment:
+      ALERT_WEBHOOK_URL: ${ALERT_WEBHOOK_URL:?Set ALERT_WEBHOOK_URL in .env}
+    ports:
+      - "9093:9093"
+    volumes:
+      - alertmanager-data:/alertmanager
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+
+  grafana:
+    image: grafana/grafana:11.5.2
+    container_name: latanda-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in .env}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: latanda-node-exporter
+    restart: unless-stopped
+    command:
+      - --path.rootfs=/host
+    pid: host
+    ports:
+      - "9100:9100"
+    volumes:
+      - /:/host:ro,rslave
+
+volumes:
+  prometheus-data:
+  alertmanager-data:
+  grafana-data:

--- a/monitoring/grafana/dashboards/block-production.json
+++ b/monitoring/grafana/dashboards/block-production.json
@@ -1,0 +1,42 @@
+{
+  "uid": "latanda-block-production",
+  "title": "La Tanda Block Production",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "timezone": "browser",
+  "tags": ["latanda", "blocks"],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Latest Height",
+      "gridPos": {"x": 0, "y": 0, "w": 8, "h": 4},
+      "targets": [{"expr": "cometbft_consensus_height", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "stat",
+      "title": "Average Block Time",
+      "gridPos": {"x": 8, "y": 0, "w": 8, "h": 4},
+      "targets": [{"expr": "rate(cometbft_consensus_block_interval_seconds_sum[5m]) / rate(cometbft_consensus_block_interval_seconds_count[5m])", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "stat",
+      "title": "Blocks Produced",
+      "gridPos": {"x": 16, "y": 0, "w": 8, "h": 4},
+      "targets": [{"expr": "increase(cometbft_consensus_block_parts_total[1h])", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Height Progression",
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8},
+      "targets": [{"expr": "cometbft_consensus_height", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Block Interval",
+      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8},
+      "targets": [{"expr": "rate(cometbft_consensus_block_interval_seconds_sum[5m]) / rate(cometbft_consensus_block_interval_seconds_count[5m])", "legendFormat": "{{validator}}"}]
+    }
+  ]
+}
+

--- a/monitoring/grafana/dashboards/network-health.json
+++ b/monitoring/grafana/dashboards/network-health.json
@@ -1,0 +1,42 @@
+{
+  "uid": "latanda-network-health",
+  "title": "La Tanda Network Health",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "timezone": "browser",
+  "tags": ["latanda", "network"],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Total Validators",
+      "gridPos": {"x": 0, "y": 0, "w": 8, "h": 4},
+      "targets": [{"expr": "count(cometbft_consensus_validator_power)", "legendFormat": "validators"}]
+    },
+    {
+      "type": "stat",
+      "title": "Bonded Stake",
+      "gridPos": {"x": 8, "y": 0, "w": 8, "h": 4},
+      "targets": [{"expr": "sum(cosmos_staking_bonded_tokens)", "legendFormat": "LTD"}]
+    },
+    {
+      "type": "stat",
+      "title": "Active Governance Proposals",
+      "gridPos": {"x": 16, "y": 0, "w": 8, "h": 4},
+      "targets": [{"expr": "cosmos_gov_proposals_active_total", "legendFormat": "active"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Network Peer Count",
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8},
+      "targets": [{"expr": "sum(cometbft_p2p_peers)", "legendFormat": "peers"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Validator Availability",
+      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8},
+      "targets": [{"expr": "sum(up{job=\"latandad_tendermint\"}) / count(up{job=\"latandad_tendermint\"}) * 100", "legendFormat": "availability %"}]
+    }
+  ]
+}
+

--- a/monitoring/grafana/dashboards/node-performance.json
+++ b/monitoring/grafana/dashboards/node-performance.json
@@ -1,0 +1,39 @@
+{
+  "uid": "latanda-node-performance",
+  "title": "La Tanda Node Performance",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "15s",
+  "timezone": "browser",
+  "tags": ["latanda", "node"],
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "CPU Usage %",
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+      "targets": [{"expr": "100 - (avg by(instance) (rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)", "legendFormat": "{{instance}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Memory Usage %",
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+      "targets": [{"expr": "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100", "legendFormat": "{{instance}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Disk Usage %",
+      "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8},
+      "targets": [{"expr": "(1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"})) * 100", "legendFormat": "{{mountpoint}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Network I/O",
+      "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "rate(node_network_receive_bytes_total{device!=\"lo\"}[5m])", "legendFormat": "rx {{device}}"},
+        {"expr": "rate(node_network_transmit_bytes_total{device!=\"lo\"}[5m])", "legendFormat": "tx {{device}}"}
+      ]
+    }
+  ]
+}
+

--- a/monitoring/grafana/dashboards/validator-overview.json
+++ b/monitoring/grafana/dashboards/validator-overview.json
@@ -1,0 +1,47 @@
+{
+  "uid": "latanda-validator-overview",
+  "title": "La Tanda Validator Overview",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "timezone": "browser",
+  "tags": ["latanda", "validator"],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Voting Power",
+      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4},
+      "targets": [{"expr": "cometbft_consensus_validator_power", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "stat",
+      "title": "Jail Status",
+      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 4},
+      "targets": [{"expr": "cosmos_staking_validator_jailed", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "stat",
+      "title": "Missed Blocks",
+      "gridPos": {"x": 12, "y": 0, "w": 6, "h": 4},
+      "targets": [{"expr": "cosmos_slashing_validator_missed_blocks", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "stat",
+      "title": "Peer Count",
+      "gridPos": {"x": 18, "y": 0, "w": 6, "h": 4},
+      "targets": [{"expr": "cometbft_p2p_peers", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Validator Uptime %",
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8},
+      "targets": [{"expr": "100 * avg_over_time(up{job=\"latandad_tendermint\"}[1h])", "legendFormat": "{{validator}}"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Missed Block Ratio",
+      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8},
+      "targets": [{"expr": "cosmos_slashing_validator_missed_blocks / 10000", "legendFormat": "{{validator}}"}]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/latanda.yml
+++ b/monitoring/grafana/provisioning/dashboards/latanda.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: La Tanda Chain
+    orgId: 1
+    folder: La Tanda Chain
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+

--- a/monitoring/prometheus/alerts.yml
+++ b/monitoring/prometheus/alerts.yml
@@ -1,0 +1,47 @@
+groups:
+  - name: latanda-validator-alerts
+    rules:
+      - alert: ValidatorJailed
+        expr: cosmos_staking_validator_jailed == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Validator {{ $labels.validator }} is jailed"
+          description: "The validator is marked jailed by the staking module and is not signing blocks."
+
+      - alert: MissedBlocksCritical
+        expr: cosmos_slashing_validator_missed_blocks > 4000
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Validator {{ $labels.validator }} missed more than 40% of the 10,000 block signing window"
+          description: "The chain uses min_signed_per_window 0.5, so jail risk begins above 5,000 missed blocks."
+
+      - alert: MissedBlocksWarning
+        expr: cosmos_slashing_validator_missed_blocks > 2000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Validator {{ $labels.validator }} missed more than 20% of the 10,000 block signing window"
+          description: "Investigate node health, peers, disk, and validator process logs."
+
+      - alert: LowPeerCount
+        expr: cometbft_p2p_peers < 3
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Validator {{ $labels.validator }} has fewer than 3 peers"
+          description: "Peer count has stayed below the recommended minimum for 10 minutes."
+
+      - alert: ActiveGovernanceProposal
+        expr: increase(cosmos_gov_proposals_active_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: info
+        annotations:
+          summary: "New active governance proposal detected"
+          description: "A governance proposal became active on La Tanda Chain."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,43 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    network: latanda-testnet
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - prometheus:9090
+
+  - job_name: node_exporter
+    static_configs:
+      - targets:
+          - node-exporter:9100
+
+  - job_name: latandad_tendermint
+    metrics_path: /metrics
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/targets/validators.yml
+        refresh_interval: 1m
+    relabel_configs:
+      - source_labels: [__meta_filepath]
+        target_label: target_source
+
+  - job_name: cosmos_sdk_rest
+    metrics_path: /metrics
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/targets/rest-api.yml
+        refresh_interval: 1m
+

--- a/monitoring/prometheus/targets/rest-api.yml
+++ b/monitoring/prometheus/targets/rest-api.yml
@@ -1,0 +1,6 @@
+- labels:
+    validator: replace-with-validator-name
+    network: latanda-testnet
+  targets:
+    - validator-host.example.com:1317
+

--- a/monitoring/prometheus/targets/validators.yml
+++ b/monitoring/prometheus/targets/validators.yml
@@ -1,0 +1,6 @@
+- labels:
+    validator: replace-with-validator-name
+    network: latanda-testnet
+  targets:
+    - validator-host.example.com:26660
+


### PR DESCRIPTION
Fixes #267

## Summary
- Adds a deployable `monitoring/` stack with pinned Prometheus, Alertmanager, Grafana, and node_exporter images.
- Adds Prometheus scrape config for Tendermint metrics on `:26660`, Cosmos SDK REST metrics on `:1317/metrics`, node_exporter, and Alertmanager wiring.
- Adds four auto-provisioned Grafana dashboards: Validator Overview, Block Production, Network Health, and Node Performance.
- Adds alert rules for jailed validators, missed block thresholds, peer count, and active governance proposals.
- Adds validator-facing deployment and onboarding docs.

## Codebase verification answer
The current slashing params from `https://latanda.online/chain/api/cosmos/slashing/v1beta1/params` are:
- `signed_blocks_window`: `10000`
- `min_signed_per_window`: `0.500000000000000000`

That means the warning and critical missed-block rules use 2,000 and 4,000 missed blocks respectively, with jail risk beginning above roughly 5,000 missed blocks in the window.

## Notes
- Validator targets are configured through Prometheus file service discovery in `monitoring/prometheus/targets/`, so operators can update endpoints without editing the main Prometheus config.
- No `latanda.online` validator endpoints are hardcoded into the stack.
- Alertmanager uses `--config.expand-env` so `ALERT_WEBHOOK_URL` can be provided through `.env`.

## Verification
- Parsed all Grafana dashboard JSON files successfully.
- Parsed all monitoring YAML files successfully with PyYAML.
- `git diff --check -- monitoring`

Docker CLI is not installed in this local environment, so I could not run `docker compose config` here.