### PR TITLE
Improve notification center grouping, actions, history, and badges

### DIFF
--- a/css/components/notification-center.css
+++ b/css/components/notification-center.css
@@ -1355,3 +1355,174 @@
     justify-content: center;
     gap: 6px;
 }
+
+/* v4.25.14: grouped notifications, inline actions, and history page */
+.notification-group-members {
+    margin-top: 10px;
+    padding: 10px 12px;
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.72);
+}
+.notification-group-member {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6px 0;
+    color: var(--text-primary, #f8fafc);
+    font-size: 0.86rem;
+}
+.notification-group-member + .notification-group-member {
+    border-top: 1px solid rgba(148, 163, 184, 0.1);
+}
+.notification-group-member small {
+    color: var(--text-secondary, #94a3b8);
+    text-align: right;
+}
+.notification-inline-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 10px;
+}
+.notification-action-btn,
+.notification-expand {
+    border: 1px solid rgba(0, 255, 255, 0.24);
+    border-radius: 8px;
+    background: rgba(0, 255, 255, 0.08);
+    color: var(--accent-cyan, #00ffff);
+    cursor: pointer;
+    font-size: 0.78rem;
+    font-weight: 700;
+    padding: 7px 10px;
+}
+.notification-action-btn:disabled {
+    cursor: wait;
+    opacity: 0.65;
+}
+.notification-expand {
+    align-self: center;
+    min-width: 34px;
+    height: 34px;
+    padding: 0;
+}
+.notification-item.expanded .notification-expand {
+    transform: rotate(180deg);
+}
+.notification-history-page {
+    min-height: 100vh;
+    padding: 32px 20px 48px;
+    background: var(--bg-primary, #0a0e17);
+    color: var(--text-primary, #f8fafc);
+}
+.notification-history-shell {
+    width: min(980px, 100%);
+    margin: 0 auto;
+}
+.notification-history-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 18px;
+    margin-bottom: 18px;
+}
+.notification-history-kicker {
+    margin: 0 0 6px;
+    color: var(--accent-cyan, #00ffff);
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+.notification-history-header h1 {
+    margin: 0;
+    font-size: 2rem;
+    letter-spacing: 0;
+}
+.notification-history-search {
+    width: min(360px, 100%);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0 14px;
+    border: 1px solid rgba(148, 163, 184, 0.18);
+    border-radius: 12px;
+    background: var(--bg-secondary, #111827);
+    color: var(--text-secondary, #94a3b8);
+}
+.notification-history-search input {
+    width: 100%;
+    min-height: 44px;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--text-primary, #f8fafc);
+    font: inherit;
+}
+.notification-history-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+.notification-history-filter {
+    border: 1px solid rgba(148, 163, 184, 0.16);
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.08);
+    color: var(--text-secondary, #94a3b8);
+    cursor: pointer;
+    font-weight: 700;
+    padding: 8px 13px;
+}
+.notification-history-filter.active {
+    border-color: rgba(0, 255, 255, 0.35);
+    background: rgba(0, 255, 255, 0.12);
+    color: var(--accent-cyan, #00ffff);
+}
+.notification-history-list {
+    display: grid;
+    gap: 10px;
+}
+.notification-history-list .notification-item {
+    margin-bottom: 0;
+}
+.notification-history-skeleton {
+    height: 92px;
+    border-radius: 14px;
+    background: linear-gradient(90deg, rgba(148, 163, 184, 0.08), rgba(148, 163, 184, 0.16), rgba(148, 163, 184, 0.08));
+    background-size: 220% 100%;
+    animation: notification-skeleton 1.2s ease infinite;
+}
+.notification-history-more {
+    display: block;
+    margin: 18px auto 0;
+    border: 1px solid rgba(0, 255, 255, 0.26);
+    border-radius: 10px;
+    background: rgba(0, 255, 255, 0.1);
+    color: var(--accent-cyan, #00ffff);
+    cursor: pointer;
+    font-weight: 800;
+    padding: 11px 18px;
+}
+@keyframes notification-skeleton {
+    0% { background-position: 0 0; }
+    100% { background-position: -220% 0; }
+}
+@media (max-width: 640px) {
+    .notification-history-page {
+        padding: 18px 12px 84px;
+    }
+    .notification-history-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+    .notification-history-header h1 {
+        font-size: 1.5rem;
+    }
+    .notification-group-member {
+        flex-direction: column;
+        gap: 2px;
+    }
+    .notification-group-member small {
+        text-align: left;
+    }
+}

--- a/js/components-loader.js
+++ b/js/components-loader.js
@@ -202,3 +202,6 @@ document.addEventListener('DOMContentLoaded', function() {
         LaTandaComponentLoader.loadMobileDrawer();
     }, 500);
 });
+
+// v4.25.14: keep mobile/sidebar notification badges in sync across pages
+(function(){function updateNotificationBadges(count){document.querySelectorAll('[data-notification-badge],#mobileNotifBadge,#sidebarNotifBadge,#notifBadge,.notification-badge,.lt-badge,#notificationCount').forEach(function(badge){badge.textContent=count>99?"99+":String(count);badge.style.display=count>0?"flex":"none";badge.classList.toggle("urgent",count>=5)})}try{var stored=parseInt(localStorage.getItem("notifications_unread_count")||"0",10);if(stored>0)updateNotificationBadges(stored)}catch(error){}try{var channel=new BroadcastChannel("notifications");channel.onmessage=function(event){if(event.data&&event.data.type==="unread")updateNotificationBadges(event.data.count||0)}}catch(error){}window.addEventListener("storage",function(event){if(event.key==="notifications_unread_count")updateNotificationBadges(parseInt(event.newValue||"0",10))});window.addEventListener("notifications:unread",function(event){updateNotificationBadges(event.detail&&event.detail.count||0)})})();

--- a/js/components/notification-center.js
+++ b/js/components/notification-center.js
@@ -1417,3 +1417,122 @@ document.addEventListener("headerLoaded", function() {
 setTimeout(function() {
     if (window.notificationCenter) window.notificationCenter.updateBadge();
 }, 2000);
+
+// v4.25.14: notification grouping, inline actions, history page, and cross-page badge sync
+(function(){
+if(!window.NotificationCenter||window.NotificationCenter.prototype.__improvementsPatched)return;
+var proto=window.NotificationCenter.prototype;
+proto.__improvementsPatched=true;
+var originalRender=proto.renderNotifications;
+var originalMarkAsRead=proto.markAsRead;
+var originalUpdateBadge=proto.updateBadge;
+var originalLoad=proto.loadNotificationsFromAPI;
+var originalLocal=proto.loadFromLocalStorage;
+var originalDelete=proto.deleteNotification;
+var baseTitle=document.title.replace(/^\(\d+\)\s+/,"");
+var channel=null;
+try{channel=new BroadcastChannel("notifications")}catch(_){}
+function targetId(n){var d=n&&n.data||{};return d.target_id||d.post_id||d.group_id||d.order_id||d.payment_id||d.user_id||d.friend_id||d.tanda_id||d.id||n.target_id||n.id}
+function actionText(n){var type=n.originalType||n.type||"";if(type==="friend_request")return"te envio una solicitud";if(type==="group_invitation")return"te invitaron a un grupo";if(type==="payment_due")return"tiene un pago pendiente";if(type==="marketplace_order_confirmation")return"requiere confirmacion";return n.message||"actualizaron un elemento"}
+function actor(n){var d=n&&n.data||{};return d.actor_name||d.user_name||d.sender_name||d.from_name||d.name||n.actor||"Alguien"}
+function groupKey(n){var type=n.originalType||n.type||"";var id=targetId(n);return type&&id?type+"::"+id:""}
+function within24h(a,b){return Math.abs(new Date(a.time)-new Date(b.time))<=86400000}
+proto.getGroupedNotifications=function(items){
+ var out=[],buckets={};
+ (items||[]).forEach(function(n){
+  var key=groupKey(n);
+  if(!key){out.push(n);return}
+  if(!buckets[key]||!within24h(buckets[key][0],n)){buckets[key]=[n];out.push(n);return}
+  buckets[key].push(n);
+ });
+ return out.map(function(n){
+  var members=buckets[groupKey(n)];
+  if(!members||members.length<2)return n;
+  var names=members.map(actor).filter(Boolean);
+  var unique=[...new Set(names)];
+  var shown=unique.slice(0,2).join(", ");
+  if(unique.length>2)shown+=", +"+(unique.length-2)+" mas";
+  return Object.assign({},n,{_isGroup:true,_groupMembers:members,_groupExpanded:false,id:"group:"+groupKey(n)+":"+new Date(n.time).getTime(),read:members.every(function(x){return x.read}),title:shown,message:actionText(n),time:members[0].time});
+ });
+};
+proto.getNotificationActions=function(n){
+ var type=n.originalType||n.type||"",d=n.data||{};
+ if(type==="group_invitation")return[{key:"accept",label:"Aceptar",url:"/api/groups/"+encodeURIComponent(d.group_id||d.target_id||"")+"/join",method:"POST"},{key:"reject",label:"Rechazar",url:"/api/groups/"+encodeURIComponent(d.group_id||d.target_id||"")+"/decline",method:"POST"}];
+ if(type==="marketplace_order_confirmation")return[{key:"confirm",label:"Confirmar",url:"/api/marketplace/orders/"+encodeURIComponent(d.order_id||d.target_id||"")+"/confirm",method:"POST"},{key:"dispute",label:"Disputar",url:"/api/marketplace/orders/"+encodeURIComponent(d.order_id||d.target_id||"")+"/dispute",method:"POST"}];
+ if(type==="friend_request")return[{key:"accept",label:"Aceptar",url:"/api/social/friends/"+encodeURIComponent(d.user_id||d.friend_id||d.target_id||"")+"/accept",method:"POST"},{key:"reject",label:"Rechazar",url:"/api/social/friends/"+encodeURIComponent(d.user_id||d.friend_id||d.target_id||"")+"/reject",method:"POST"}];
+ if(type==="payment_due")return[{key:"pay",label:"Pagar",url:this.getNavigationUrl(n)||"/pagos.html",method:"NAV"}];
+ return[{key:"view",label:"Ver",url:this.getNavigationUrl(n),method:"NAV"}];
+};
+proto.renderNotificationCard=function(n){
+ var navUrl=this.getNavigationUrl(n)||"",actions=this.getNotificationActions(n),members=n._groupMembers||[];
+ var classes=["notification-item",!n.read?"unread":"",navUrl?"clickable":"",n.urgent?"urgent":"","type-"+n.type,n._isGroup?"notification-group":""].filter(Boolean).join(" ");
+ var memberHtml=n._isGroup?'<div class="notification-group-members" hidden>'+members.map(function(m){return'<div class="notification-group-member" data-id="'+proto.escapeHtml(String(m.id))+'"><span>'+proto.escapeHtml(actor(m))+'</span><small>'+proto.escapeHtml(m.message||"")+'</small></div>'}).join("")+'</div>':"";
+ return '<div class="'+classes+'" data-id="'+this.escapeHtml(String(n.id))+'" data-nav="'+this.escapeHtml(navUrl)+'" data-type="'+this.escapeHtml(n.type)+'">'+
+ '<div class="notification-icon">'+this.escapeHtml(n.icon||"🔔")+'</div><div class="notification-content"><h4 class="notification-title">'+this.escapeHtml(n.title||"Notificacion")+'</h4><p class="notification-message">'+this.escapeHtml(n.message||"")+'</p>'+
+ (this.getContextLine(n)?'<span class="notification-context">'+this.escapeHtml(this.getContextLine(n))+'</span>':"")+'<span class="notification-time">'+this.getTimeAgo(n.time)+'</span>'+memberHtml+
+ '<div class="notification-inline-actions">'+actions.map(function(a){return'<button class="notification-action-btn" data-action-key="'+proto.escapeHtml(a.key)+'" data-url="'+proto.escapeHtml(a.url||"")+'" data-method="'+proto.escapeHtml(a.method||"POST")+'">'+proto.escapeHtml(a.label)+'</button>'}).join("")+'</div></div>'+
+ (n._isGroup?'<button class="notification-expand" data-id="'+this.escapeHtml(String(n.id))+'" title="Expandir">⌄</button>':(!n.read?'<button class="notification-mark-read" data-id="'+this.escapeHtml(String(n.id))+'" title="Marcar leido">✓</button>':""))+
+ '<button class="notification-delete" data-id="'+this.escapeHtml(String(n.id))+'" title="Eliminar">×</button></div>';
+};
+proto.renderNotifications=function(){
+ var list=document.getElementById("notificationList");
+ if(!list)return originalRender&&originalRender.call(this);
+ var filtered=this.currentFilter==="all"?this.notifications:this.notifications.filter(function(n){return n.type===this.currentFilter}.bind(this));
+ filtered=this.getGroupedNotifications(filtered);
+ if(filtered.length===0){list.innerHTML='<div class="notification-empty"><div class="notification-empty-icon">🔔</div><p class="notification-empty-text">No hay notificaciones</p><p class="notification-empty-subtext">Cuando recibas notificaciones, apareceran aqui</p></div>';return}
+ list.innerHTML=filtered.map(this.renderNotificationCard.bind(this)).join("");
+ this.bindNotificationListActions(list);
+ var loadMoreBtn=document.getElementById("ncLoadMoreBtn");
+ if(loadMoreBtn)loadMoreBtn.style.display=this.loadedAll?"none":"block";
+};
+proto.bindNotificationListActions=function(root){
+ root.querySelectorAll(".notification-mark-read").forEach(function(btn){btn.addEventListener("click",function(e){e.stopPropagation();this.markAsRead(btn.dataset.id)}.bind(this))}.bind(this));
+ root.querySelectorAll(".notification-delete").forEach(function(btn){btn.addEventListener("click",function(e){e.stopPropagation();this.deleteNotification(btn.dataset.id)}.bind(this))}.bind(this));
+ root.querySelectorAll(".notification-expand").forEach(function(btn){btn.addEventListener("click",function(e){e.stopPropagation();var item=btn.closest(".notification-item"),box=item&&item.querySelector(".notification-group-members");if(box){box.hidden=!box.hidden;item.classList.toggle("expanded",!box.hidden)}})});
+ root.querySelectorAll(".notification-action-btn").forEach(function(btn){btn.addEventListener("click",function(e){e.preventDefault();e.stopPropagation();this.runNotificationAction(btn)}.bind(this))}.bind(this));
+ root.querySelectorAll(".notification-item").forEach(function(item){item.addEventListener("click",function(e){if(e.target.closest("button"))return;var id=item.dataset.id,nav=item.dataset.nav;this.markAsRead(id);if(nav)window.location.href=nav}.bind(this))}.bind(this));
+};
+proto.runNotificationAction=async function(btn){
+ var method=btn.dataset.method,url=btn.dataset.url,old=btn.textContent;
+ if(!url)return;
+ if(method==="NAV"){window.location.href=url;return}
+ btn.disabled=true;btn.textContent="...";
+ try{var res=await fetch(url,{method:method||"POST",headers:Object.assign({},this.getAuthHeaders(),{"Content-Type":"application/json"}),body:JSON.stringify({})});if(!res.ok)throw new Error("No se pudo completar la accion");btn.textContent="Listo";this.showToast({type:"success",message:"Accion completada"});setTimeout(function(){btn.closest(".notification-item")&&btn.closest(".notification-item").remove()},450)}catch(err){btn.disabled=false;btn.textContent=old;this.showToast({type:"error",message:err.message||"Error al procesar"})}
+};
+proto.markAsRead=async function(id){
+ if(String(id).indexOf("group:")===0){var item=[...document.querySelectorAll(".notification-item")].find(function(el){return el.dataset.id===String(id)}),memberIds=item?[...item.querySelectorAll(".notification-group-member")].map(function(m){return m.dataset.id}):[];for(var i=0;i<memberIds.length;i++)await originalMarkAsRead.call(this,memberIds[i]);return}
+ return originalMarkAsRead.call(this,id);
+};
+proto.updateBadge=function(){
+ originalUpdateBadge&&originalUpdateBadge.call(this);
+ var count=this.unreadCount||0;
+ document.querySelectorAll('[data-notification-badge], #mobileNotifBadge, #sidebarNotifBadge, #notifBadge, .notification-badge, .lt-badge, #notificationCount').forEach(function(b){b.textContent=count>99?"99+":String(count);b.style.display=count>0?"flex":"none";b.classList.toggle("urgent",count>=5)});
+ document.title=count>0?"("+count+") "+baseTitle:baseTitle;
+ try{localStorage.setItem("notifications_unread_count",String(count))}catch(_){}
+ if(channel)channel.postMessage({type:"unread",count:count});
+ window.dispatchEvent(new CustomEvent("notifications:unread",{detail:{count:count}}));
+};
+proto.loadNotificationsFromAPI=async function(){var out=await originalLoad.apply(this,arguments);this.updateBadge();this.renderNotificationHistoryPage&&this.renderNotificationHistoryPage();return out};
+proto.loadFromLocalStorage=function(){var out=originalLocal.apply(this,arguments);this.updateBadge();return out};
+proto.deleteNotification=async function(id){var out=await originalDelete.call(this,id);this.renderNotificationHistoryPage&&this.renderNotificationHistoryPage();return out};
+proto.renderNotificationHistoryPage=function(){
+ var page=document.getElementById("notificationHistoryList");if(!page)return;
+ var q=(document.getElementById("notificationSearch")||{}).value||"",filter=(document.querySelector(".notification-history-filter.active")||{}).dataset?.filter||"all";
+ var items=(filter==="all"?this.notifications:this.notifications.filter(function(n){return n.type===filter})).filter(function(n){return !q||((n.title||"")+" "+(n.message||"")).toLowerCase().indexOf(q.toLowerCase())!==-1});
+ var limit=parseInt(page.dataset.limit||"20",10),shown=this.getGroupedNotifications(items).slice(0,limit);
+ page.innerHTML=shown.length?shown.map(this.renderNotificationCard.bind(this)).join(""):'<div class="notification-empty"><div class="notification-empty-icon">🔔</div><p class="notification-empty-text">Sin resultados</p><p class="notification-empty-subtext">Ajusta la busqueda o cambia el filtro.</p></div>';
+ this.bindNotificationListActions(page);
+ var more=document.getElementById("notificationHistoryMore");if(more)more.hidden=limit>=items.length;
+};
+function syncExternal(count){document.querySelectorAll('[data-notification-badge], #mobileNotifBadge, #sidebarNotifBadge').forEach(function(b){b.textContent=count>99?"99+":String(count);b.style.display=count>0?"flex":"none"})}
+if(channel)channel.onmessage=function(e){if(e.data&&e.data.type==="unread")syncExternal(e.data.count)};
+window.addEventListener("storage",function(e){if(e.key==="notifications_unread_count")syncExternal(parseInt(e.newValue||"0",10))});
+document.addEventListener("DOMContentLoaded",function(){
+ var search=document.getElementById("notificationSearch"),more=document.getElementById("notificationHistoryMore");
+ if(search)search.addEventListener("input",function(){window.notificationCenter&&window.notificationCenter.renderNotificationHistoryPage()});
+ document.querySelectorAll(".notification-history-filter").forEach(function(btn){btn.addEventListener("click",function(){document.querySelectorAll(".notification-history-filter").forEach(function(b){b.classList.remove("active")});btn.classList.add("active");window.notificationCenter&&window.notificationCenter.renderNotificationHistoryPage()})});
+ if(more)more.addEventListener("click",function(){var list=document.getElementById("notificationHistoryList");list.dataset.limit=String((parseInt(list.dataset.limit||"20",10)+20));window.notificationCenter&&window.notificationCenter.renderNotificationHistoryPage()});
+ window.addEventListener("scroll",function(){var list=document.getElementById("notificationHistoryList");if(!list||window.notificationCenter&&window.notificationCenter.loadedAll)return;if(window.innerHeight+window.scrollY>document.documentElement.scrollHeight-240){list.dataset.limit=String((parseInt(list.dataset.limit||"20",10)+20));window.notificationCenter&&window.notificationCenter.renderNotificationHistoryPage()}},{passive:true});
+ setTimeout(function(){window.notificationCenter&&window.notificationCenter.renderNotificationHistoryPage()},500);
+});
+})();

--- a/js/hub/sidebar-widgets.js
+++ b/js/hub/sidebar-widgets.js
@@ -251,3 +251,6 @@ if (document.readyState === 'loading') {
 
 // Make globally available
 window.SidebarWidgets = SidebarWidgets;
+
+// v4.25.14: mirror notification unread count into sidebar widgets when present
+(function(){function updateSidebarNotificationBadge(count){document.querySelectorAll('[data-notification-badge],#sidebarNotifBadge,.sidebar-notification-badge').forEach(function(badge){badge.textContent=count>99?"99+":String(count);badge.style.display=count>0?"flex":"none";badge.classList.toggle("urgent",count>=5)})}try{var stored=parseInt(localStorage.getItem("notifications_unread_count")||"0",10);if(stored>0)updateSidebarNotificationBadge(stored)}catch(error){}try{var channel=new BroadcastChannel("notifications");channel.onmessage=function(event){if(event.data&&event.data.type==="unread")updateSidebarNotificationBadge(event.data.count||0)}}catch(error){}window.addEventListener("storage",function(event){if(event.key==="notifications_unread_count")updateSidebarNotificationBadge(parseInt(event.newValue||"0",10))});window.addEventListener("notifications:unread",function(event){updateSidebarNotificationBadge(event.detail&&event.detail.count||0)})})();

--- a/notificaciones.html
+++ b/notificaciones.html
@@ -2,21 +2,45 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Notificaciones - La Tanda</title>
-    <meta http-equiv="refresh" content="0;url=/home-dashboard.html?open=notifications">
-    <script>window.location.href = '/home-dashboard.html?open=notifications';</script>
+    <link rel="stylesheet" href="css/design-tokens.css">
+    <link rel="stylesheet" href="css/components/notification-center.css">
+    <script src="js/components-loader.js" defer></script>
+    <script src="js/components/notification-center.js" defer></script>
 </head>
-<body>
-    <p>Redirigiendo a notificaciones...</p>
+<body data-sidebar data-footer>
+    <div id="global-sidebar"></div>
+    <main class="notification-history-page" id="mainContent">
+        <section class="notification-history-shell">
+            <header class="notification-history-header">
+                <div>
+                    <p class="notification-history-kicker">Centro de actividad</p>
+                    <h1>Notificaciones</h1>
+                </div>
+                <label class="notification-history-search">
+                    <i class="fas fa-search" aria-hidden="true"></i>
+                    <input id="notificationSearch" type="search" placeholder="Buscar notificaciones">
+                </label>
+            </header>
 
-    <!-- Mobile Bottom Nav -->
-    <nav class="mobile-bottom-nav" id="mobileBottomNav" style="display:none">
-        <a href="/home-dashboard.html" class="mobile-nav-item"><i class="fas fa-home"></i><span>Inicio</span></a>
-        <a href="/marketplace-social.html" class="mobile-nav-item"><i class="fas fa-store"></i><span>Mercado</span></a>
-        <a href="/recompensas.html" class="mobile-nav-item"><i class="fas fa-gift"></i><span>Rewards</span></a>
-        <a href="/mi-perfil.html" class="mobile-nav-item"><i class="fas fa-user"></i><span>Perfil</span></a>
-    </nav>
-    <style>.mobile-bottom-nav{display:none}@media(max-width:768px){.mobile-bottom-nav{display:flex!important;position:fixed;bottom:0;left:0;right:0;z-index:1000;background:rgba(10,14,23,0.95);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);border-top:1px solid rgba(0,255,255,0.08);padding:4px 0;padding-bottom:calc(4px + env(safe-area-inset-bottom))}.mobile-nav-item{flex:1;display:flex;flex-direction:column;align-items:center;gap:2px;padding:4px;text-decoration:none;color:#64748b;font-size:0.6rem;transition:color 0.2s}.mobile-nav-item i{font-size:1.1rem}.mobile-nav-item:hover{color:#00FFFF}}</style>
+            <nav class="notification-history-filters" aria-label="Filtros de notificaciones">
+                <button class="notification-history-filter active" data-filter="all">Todo</button>
+                <button class="notification-history-filter" data-filter="transactions">Pagos</button>
+                <button class="notification-history-filter" data-filter="tandas">Tandas</button>
+                <button class="notification-history-filter" data-filter="social">Social</button>
+                <button class="notification-history-filter" data-filter="system">Sistema</button>
+            </nav>
+
+            <div class="notification-history-list" id="notificationHistoryList" data-limit="20">
+                <div class="notification-history-skeleton"></div>
+                <div class="notification-history-skeleton"></div>
+                <div class="notification-history-skeleton"></div>
+            </div>
+
+            <button class="notification-history-more" id="notificationHistoryMore" hidden>Cargar mas</button>
+        </section>
+    </main>
+    <div id="latanda-footer"></div>
 </body>
 </html>


### PR DESCRIPTION
Fixes #268

## Summary
- Adds 24-hour grouping by `type + target_id` with expandable grouped entries and group-level mark-as-read behavior.
- Adds inline notification actions for group invitations, payment due, marketplace order confirmations, friend requests, and default view navigation.
- Replaces the redirect-only `notificaciones.html` stub with a standalone notification history page using the same notification card renderer as the panel.
- Adds search, filter pills, skeleton loading, load-more/infinite-scroll behavior, empty state, and responsive styling.
- Adds cross-page unread badge sync through `BroadcastChannel('notifications')`, `storage`, and a local custom event; sync updates the panel, mobile nav, sidebar widgets, and browser tab title.

## Codebase notes
- The requested `js/sidebar-widgets.js` file does not exist in this repository. The existing sidebar widget module is `js/hub/sidebar-widgets.js`, so badge sync was added there.
- Backend/API contracts are unchanged. Inline actions call existing-style endpoints and preserve the current `NotificationCenter` public API.

## Verification
- `node --check js/components/notification-center.js`
- `node --check js/components-loader.js`
- `node --check js/hub/sidebar-widgets.js`
- `git diff --check`