### PR TITLE
Fix placeholder and broken HTML links

### DIFF
--- a/admin-audit-logs-viewer.html
+++ b/admin-audit-logs-viewer.html
@@ -437,7 +437,7 @@
         // Initialize
         if (!authToken) {
             alert('No estás autenticado. Por favor inicia sesión.');
-            window.location.href = '/admin-panel.html';
+            window.location.href = '/admin-panel-v2.html';
         } else {
             loadStats();
             loadLogs(1);

--- a/analytics.html
+++ b/analytics.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Analytics PRO | La Tanda Web3 Dashboard</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"></noscript>
     <style>
         :root {

--- a/auth-enhanced.html
+++ b/auth-enhanced.html
@@ -472,6 +472,11 @@
         
         .forgot-password {
             display: block;
+            width: 100%;
+            background: none;
+            border: 0;
+            cursor: pointer;
+            padding: 0;
             text-align: right;
             font-size: 0.875rem;
             color: var(--primary);
@@ -983,11 +988,11 @@
                     <div class="error-message" id="loginPasswordError"></div>
                 </div>
                 
-                <a href="#" class="forgot-password" onclick="window.auth.showPasswordResetForm(); return false;">
+                <button type="button" class="forgot-password" onclick="window.auth.showPasswordResetForm();">
                     ¿Olvidaste tu contraseña?
-                </a>
+                </button>
                 <div style="text-align:center;margin-top:8px;">
-                    <a href="#" style="color:rgba(255,255,255,0.35);font-size:0.78rem;text-decoration:none;" onclick="var em=document.getElementById('loginEmail').value.trim(); if(!em||!window.auth.validateEmail(em)){window.auth.showError('Ingresa tu email primero');document.getElementById('loginEmail').focus();return false;} window.auth.showInfo('Enviando codigo...'); fetch('/api/auth/send-verification',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:em})}).then(function(r){return r.json()}).then(function(){window.auth.showEmailVerificationForm(em)}).catch(function(){window.auth.showEmailVerificationForm(em)}); return false;">¿Ya te registraste pero no verificaste tu email?</a>
+                    <button type="button" class="link-btn" style="color:rgba(255,255,255,0.35);font-size:0.78rem;text-decoration:none;" onclick="var em=document.getElementById('loginEmail').value.trim(); if(!em||!window.auth.validateEmail(em)){window.auth.showError('Ingresa tu email primero');document.getElementById('loginEmail').focus();return false;} window.auth.showInfo('Enviando codigo...'); fetch('/api/auth/send-verification',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:em})}).then(function(r){return r.json()}).then(function(){window.auth.showEmailVerificationForm(em)}).catch(function(){window.auth.showEmailVerificationForm(em)}); return false;">¿Ya te registraste pero no verificaste tu email?</button>
                 </div>
                 
                 <button type="submit" class="btn-primary" id="loginSubmit">
@@ -1081,7 +1086,7 @@
                 <div class="checkbox-container">
                     <input type="checkbox" id="acceptTerms" required>
                     <label for="acceptTerms">
-                        Acepto los <a href="#" target="_blank" rel="noopener noreferrer">Términos y Condiciones</a>
+                        Acepto los <a href="terms-of-service.html" target="_blank" rel="noopener noreferrer">Términos y Condiciones</a>
                     </label>
                 </div>
                 

--- a/bridge.html
+++ b/bridge.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bridge | La Tanda Web3 Cross-Chain</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"></noscript>
     <style>
         :root {

--- a/configuracion.html
+++ b/configuracion.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>⚙️ Configuración | La Tanda Web3</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"></noscript>
     <style>
         /* ================================

--- a/creator-hub.html
+++ b/creator-hub.html
@@ -1925,31 +1925,15 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-list"></i>
-                        <span>Listas</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-users"></i>
-                        <span>Comunidades</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-briefcase"></i>
-                        <span>Negocios</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-bullhorn"></i>
-                        <span>Anuncios</span>
-                    </a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item">
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2094,7 +2078,6 @@
                     <h2 style="font-size:1rem;font-weight:600;color:#fff;margin:0;">
                         <i class="fas fa-trophy" style="color:#fbbf24;margin-right:8px;"></i>Logros de Creador
                     </h2>
-                    <a href="#" style="color:#00FFFF;font-size:0.85rem;text-decoration:none;">Ver todos</a>
                 </div>
                 <div id="achievementsContainer" style="display:flex;gap:12px;overflow-x:auto;padding-bottom:8px;">
                     <!-- Achievements loaded by JS -->
@@ -2187,7 +2170,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2324,12 +2307,14 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
+            </button>
+            <button type="button" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
+                <i class="fas fa-magic" style="color:#ffd700;"></i>
                 <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/css/dashboard-layout.css
+++ b/css/dashboard-layout.css
@@ -284,6 +284,8 @@
  text-align: center;
  text-decoration: none;
  transition: all 0.2s ease;
+ cursor: pointer;
+ font-family: inherit;
 }
 .sidebar-hub-card-btn:hover {
  background: rgba(0, 255, 255, 0.1);
@@ -709,6 +711,13 @@
  transition: background 0.2s ease;
  width: 100%;
  box-sizing: border-box;
+}
+button.more-menu-item {
+ background: none;
+ border: 0;
+ cursor: pointer;
+ font-family: inherit;
+ text-align: left;
 }
 .more-menu-item:hover {
  background: rgba(255, 255, 255, 0.08);

--- a/css/mobile-drawer.css
+++ b/css/mobile-drawer.css
@@ -159,6 +159,14 @@
  font-weight: 500;
  transition: all 0.2s ease;
 }
+button.mobile-drawer-item {
+ width: 100%;
+ background: none;
+ border: 0;
+ cursor: pointer;
+ font-family: inherit;
+ text-align: left;
+}
 .mobile-drawer-item:hover,
 .mobile-drawer-item:active {
  background: rgba(0, 255, 255, 0.08);

--- a/documentation.html
+++ b/documentation.html
@@ -18,7 +18,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Documentación - La Tanda Web3</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <style>
         :root {

--- a/explorar.html
+++ b/explorar.html
@@ -1925,31 +1925,15 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-list"></i>
-                        <span>Listas</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-users"></i>
-                        <span>Comunidades</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-briefcase"></i>
-                        <span>Negocios</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-bullhorn"></i>
-                        <span>Anuncios</span>
-                    </a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item">
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2048,7 +2032,6 @@
                     <h2 style="font-size:1.1rem;font-weight:600;color:#fff;margin:0;">
                         <i class="fas fa-newspaper" style="color:#00FFFF;margin-right:8px;"></i>Noticias Financieras
                     </h2>
-                    <a href="#" style="color:#00FFFF;font-size:0.85rem;text-decoration:none;">Ver más</a>
                 </div>
                 <div id="newsContainer" class="explore-news-list" style="display:flex;flex-direction:column;gap:12px;">
                     <!-- News items will be loaded here -->
@@ -2166,7 +2149,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2303,12 +2286,14 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
+            </button>
+            <button type="button" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
+                <i class="fas fa-magic" style="color:#ffd700;"></i>
                 <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/gestionar.html
+++ b/gestionar.html
@@ -379,7 +379,7 @@
 
         // Alerts
         if (sp.pending > 0) {
-            html += '<div class="gm-alert gm-alert-warn"><i class="fas fa-exclamation-triangle"></i> ' + sp.pending + ' pago(s) pendiente(s) de verificacion — <a href="#" data-action="go-pagos-verificar" style="color:inherit;font-weight:600;">Verificar</a></div>';
+            html += '<div class="gm-alert gm-alert-warn"><i class="fas fa-exclamation-triangle"></i> ' + sp.pending + ' pago(s) pendiente(s) de verificacion — <button type="button" data-action="go-pagos-verificar" style="background:none;border:0;padding:0;color:inherit;font-weight:600;cursor:pointer;">Verificar</button></div>';
         }
 
         // Overview stats

--- a/governance.html
+++ b/governance.html
@@ -384,7 +384,7 @@
                         <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
                         <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
                         <div class="more-menu-divider"></div>
-                        <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                        <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                     </div>
                 </div>
             </nav>

--- a/groups-advanced-system.html
+++ b/groups-advanced-system.html
@@ -73,13 +73,9 @@
                 <div class="nav-menu-item nav-more-btn" id="navMoreBtn" data-action="toggle-more-menu" role="button" aria-expanded="false"><i class="fas fa-ellipsis-h"></i><span>Mas</span></div>
                 <div class="more-menu-dropdown" id="moreMenuDropdown" role="menu">
                     <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
-                    <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                    <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                 </div>
                 </div>
             </nav>
@@ -1514,7 +1510,7 @@
             <a href="/mensajes.html" class="mobile-drawer-item"><i class="fas fa-envelope"></i><span>Mensajes</span></a>
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></a>
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item"><i class="fas fa-ticket-alt"></i><span>Loteria</span></a>
             <div class="mobile-drawer-divider"></div>
             <a href="/mi-perfil.html" class="mobile-drawer-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>

--- a/guardados.html
+++ b/guardados.html
@@ -1925,31 +1925,15 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-list"></i>
-                        <span>Listas</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-users"></i>
-                        <span>Comunidades</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-briefcase"></i>
-                        <span>Negocios</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-bullhorn"></i>
-                        <span>Anuncios</span>
-                    </a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item">
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2119,7 +2103,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2256,12 +2240,14 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
+            </button>
+            <button type="button" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
+                <i class="fas fa-magic" style="color:#ffd700;"></i>
                 <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/home-dashboard.html
+++ b/home-dashboard.html
@@ -1130,10 +1130,10 @@
                         <i class="fas fa-cog"></i>
                         <span>Configuración</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesión</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -1330,10 +1330,10 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/index.html
+++ b/index.html
@@ -830,11 +830,15 @@
             gap: 8px;
             padding: 18px 40px;
             background: white;
+            border: 0;
             color: var(--primary);
             border-radius: 12px;
             font-size: 1.1rem;
             font-weight: 700;
             transition: all 0.2s;
+            cursor: pointer;
+            font-family: inherit;
+            text-decoration: none;
         }
         
         .cta-btn:hover {
@@ -1768,10 +1772,10 @@
                 Únete a la comunidad de ahorro más grande de Honduras. 
                 Tu futuro financiero comienza aquí.
             </p>
-            <a href="javascript:void(0)" class="cta-btn" onclick="scrollToRegister()" role="button">
+            <button type="button" class="cta-btn" onclick="scrollToRegister()">
                 <i class="fas fa-rocket"></i>
                 Crear Cuenta Gratis
-            </a>
+            </button>
         </div>
     </section>
     

--- a/lending.html
+++ b/lending.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lending | La Tanda Web3 DeFi</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"></noscript>
     <style>
         :root {

--- a/lottery-predictor.html
+++ b/lottery-predictor.html
@@ -693,6 +693,22 @@
             font-size: 0.85rem;
         }
 
+        .link-action-button {
+            background: none;
+            border: 0;
+            padding: 0;
+            color: var(--gold);
+            text-decoration: none;
+            font: inherit;
+            font-size: 0.85rem;
+            cursor: pointer;
+        }
+
+        .footer-disclaimer .link-action-button {
+            color: var(--purple);
+            font-size: inherit;
+        }
+
         .achievements-preview {
             background: rgba(30,30,60,0.5);
             padding: 20px;
@@ -1237,7 +1253,7 @@
             <div class="achievements-preview">
                 <div class="section-header">
                     <h3>🏅 Logros</h3>
-                    <a href="#" onclick="showAllAchievements(); return false;">Ver todos →</a>
+                    <button type="button" class="link-action-button" onclick="showAllAchievements()">Ver todos →</button>
                 </div>
                 <div class="achievements-grid" id="achievementsGrid">
                     <!-- Badges loaded dynamically -->
@@ -1248,7 +1264,7 @@
             <div class="mini-leaderboard">
                 <div class="section-header">
                     <h3>🏆 Ranking Semanal</h3>
-                    <a href="#" onclick="showFullLeaderboard(); return false;">Ver completo →</a>
+                    <button type="button" class="link-action-button" onclick="showFullLeaderboard()">Ver completo →</button>
                 </div>
                 <div class="leaderboard-list" id="leaderboardList">
                     <!-- Leaderboard loaded dynamically -->
@@ -1344,7 +1360,7 @@
         <div class="footer-disclaimer">
             ⚠️ <strong>Solo entretenimiento.</strong> Las predicciones no garantizan resultados.
             Juega responsablemente. +18 años.<br>
-            <a href="#" onclick="showDisclaimer(); return false;">Ver términos completos</a>
+            <button type="button" class="link-action-button" onclick="showDisclaimer()">Ver términos completos</button>
         </div>
     </main>
 

--- a/mensajes.html
+++ b/mensajes.html
@@ -1925,31 +1925,15 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-list"></i>
-                        <span>Listas</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-users"></i>
-                        <span>Comunidades</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-briefcase"></i>
-                        <span>Negocios</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-bullhorn"></i>
-                        <span>Anuncios</span>
-                    </a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item">
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2106,7 +2090,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2243,14 +2227,14 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
-            <a href="#" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
+            </button>
+            <button type="button" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
                 <i class="fas fa-magic" style="color:#ffd700;"></i>
                 <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/mi-perfil.html
+++ b/mi-perfil.html
@@ -603,7 +603,7 @@
                                         var date = new Date(c.requested_at).toLocaleDateString('es-HN', { day:'numeric', month:'short', hour:'2-digit', minute:'2-digit' });
                                         return '<div style="display:flex;justify-content:space-between;align-items:center;padding:6px 0;border-bottom:1px solid rgba(255,255,255,0.05);font-size:0.75rem;">' +
                                             '<div><span style="color:' + statusColor + ';font-weight:500;">' + c.status + '</span> <span style="color:var(--text-secondary);">' + date + '</span></div>' +
-                                            '<div style="font-weight:600;">' + parseFloat(c.amount_ltd).toFixed(2) + ' LTD' + (c.tx_hash ? ' <a href="#" title="' + _esc(c.tx_hash) + '" style="color:#00FFFF;font-size:0.65rem;" onclick="navigator.clipboard.writeText(this.dataset.hash);this.textContent=\'Copiado!\';return false;" data-hash="' + _esc(c.tx_hash) + '">TX</a>' : '') + '</div>' +
+                                            '<div style="font-weight:600;">' + parseFloat(c.amount_ltd).toFixed(2) + ' LTD' + (c.tx_hash ? ' <button type="button" title="' + _esc(c.tx_hash) + '" style="background:none;border:0;padding:0;color:#00FFFF;font-size:0.65rem;cursor:pointer;" onclick="navigator.clipboard.writeText(this.dataset.hash);this.textContent=\'Copiado!\';" data-hash="' + _esc(c.tx_hash) + '">TX</button>' : '') + '</div>' +
                                         '</div>';
                                     }).join('');
                                 } catch(e) { div.innerHTML = '<div style="color:#f87171;">Error</div>'; }

--- a/mineria.html
+++ b/mineria.html
@@ -278,31 +278,15 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-list"></i>
-                        <span>Listas</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-users"></i>
-                        <span>Comunidades</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-briefcase"></i>
-                        <span>Negocios</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-bullhorn"></i>
-                        <span>Anuncios</span>
-                    </a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item">
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>

--- a/my-tandas.html
+++ b/my-tandas.html
@@ -594,13 +594,9 @@
                 <div class="nav-menu-item nav-more-btn" id="navMoreBtn" data-action="toggle-more-menu" role="button" aria-expanded="false"><i class="fas fa-ellipsis-h"></i><span>Mas</span></div>
                 <div class="more-menu-dropdown" id="moreMenuDropdown" role="menu">
                     <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
-                    <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                    <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                 </div>
                 </div>
             </nav>

--- a/my-wallet.css
+++ b/my-wallet.css
@@ -440,6 +440,15 @@ body {
     gap: 12px;
 }
 
+button.setting-item {
+    width: 100%;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+}
+
 .setting-item:hover {
     background: var(--bg-section);
     color: var(--text-primary);

--- a/my-wallet.html
+++ b/my-wallet.html
@@ -258,36 +258,36 @@
                             <h4>Settings del Wallet</h4>
                         </div>
                         <div class="dropdown-content">
-                            <a href="#" class="setting-item" onclick="toggleCurrencyPreference()">
+                            <button type="button" class="setting-item" onclick="toggleCurrencyPreference()">
                                 <i class="fas fa-dollar-sign"></i>
                                 <span>Moneda Principal</span>
                                 <span class="setting-value" id="currencyPreference">USD</span>
-                            </a>
-                            <a href="#" class="setting-item" onclick="toggleNotifications()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="toggleNotifications()">
                                 <i class="fas fa-bell"></i>
                                 <span>Notificaciones</span>
                                 <span class="setting-toggle" id="notificationToggle">ON</span>
-                            </a>
-                            <a href="#" class="setting-item" onclick="showSecuritySettings()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="showSecuritySettings()">
                                 <i class="fas fa-shield-alt"></i>
                                 <span>Security</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
-                            <a href="#" class="setting-item" onclick="showLightningWalletConfig()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="showLightningWalletConfig()">
                                 <i class="fas fa-bolt"></i>
                                 <span>Lightning Wallet</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
-                            <a href="#" class="setting-item" onclick="exportWalletData()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="exportWalletData()">
                                 <i class="fas fa-download"></i>
                                 <span>Exportar Datos</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
-                            <a href="#" class="setting-item" onclick="showPrivacySettings()">
+                            </button>
+                            <button type="button" class="setting-item" onclick="showPrivacySettings()">
                                 <i class="fas fa-user-secret"></i>
                                 <span>Privacidad</span>
                                 <i class="fas fa-chevron-right"></i>
-                            </a>
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/nft-memberships.html
+++ b/nft-memberships.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>💎 NFT Memberships | La Tanda Web3</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"></noscript>
     <style>
         /* ================================

--- a/perfil.html
+++ b/perfil.html
@@ -320,13 +320,9 @@
                 <div class="nav-menu-item nav-more-btn" id="navMoreBtn" data-action="toggle-more-menu" role="button" aria-expanded="false" aria-controls="moreMenuDropdown" aria-label="Mas opciones"><i class="fas fa-ellipsis-h"></i><span>Mas</span></div>
                 <div class="more-menu-dropdown" id="moreMenuDropdown" role="menu">
                     <a href="perfil.html" class="more-menu-item" id="navProfileLink"><i class="fas fa-user"></i><span>Perfil</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-list"></i><span>Listas</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-users"></i><span>Comunidades</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-briefcase"></i><span>Negocios</span></a>
-                    <a href="#" class="more-menu-item"><i class="fas fa-bullhorn"></i><span>Anuncios</span></a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
-                    <a href="#" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></a>
+                    <button type="button" class="more-menu-item" data-action="logout"><i class="fas fa-sign-out-alt"></i><span>Cerrar Sesion</span></button>
                 </div>
                 </div>
             </nav>
@@ -366,7 +362,7 @@
             <a href="/mensajes.html" class="mobile-drawer-item"><i class="fas fa-envelope"></i><span>Mensajes</span></a>
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></a>
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item"><i class="fas fa-ticket-alt"></i><span>Loteria</span></a>
             <div class="mobile-drawer-divider"></div>
             <a href="/mi-perfil.html" class="mobile-drawer-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>
@@ -445,8 +441,8 @@
     function parsePostContent(text) {
         if (!text) return '';
         var escaped = esc(text);
-        escaped = escaped.replace(/@([\w\-\.]+)/g, '<a href="#" class="pf-mention" data-handle="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">@$1</a>');
-        escaped = escaped.replace(/#([\wáéíóúñÁÉÍÓÚÑ]+)/g, '<a href="#" class="pf-hashtag" data-tag="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">#$1</a>');
+        escaped = escaped.replace(/@([\w\-\.]+)/g, '<a href="perfil.html?handle=$1" class="pf-mention" data-handle="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">@$1</a>');
+        escaped = escaped.replace(/#([\wáéíóúñÁÉÍÓÚÑ]+)/g, '<a href="explorar.html?hashtag=$1" class="pf-hashtag" data-tag="$1" style="color:var(--ds-cyan,#00FFFF);text-decoration:none;">#$1</a>');
         escaped = escaped.replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener" style="color:var(--ds-cyan,#00FFFF);text-decoration:underline;">$1</a>');
         return escaped;
     }

--- a/recompensas.html
+++ b/recompensas.html
@@ -327,7 +327,7 @@
             <a href="/mensajes.html" class="mobile-drawer-item"><i class="fas fa-envelope"></i><span>Mensajes</span></a>
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></a>
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia"><i class="fas fa-robot" style="color:#00FFFF;"></i><span>MIA Assistant</span></button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item"><i class="fas fa-ticket-alt"></i><span>Loteria</span></a>
             <div class="mobile-drawer-divider"></div>
             <a href="/mi-perfil.html" class="mobile-drawer-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>

--- a/seguridad.html
+++ b/seguridad.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>🛡️ Centro de Seguridad | La Tanda Web3</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"></noscript>
     <style>
         /* ================================

--- a/staking.html
+++ b/staking.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Staking | La Tanda Web3 DeFi</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"></noscript>
     <style>
         /* ================================

--- a/trabajo.html
+++ b/trabajo.html
@@ -1925,31 +1925,15 @@
                         <i class="fas fa-user"></i>
                         <span>Perfil</span>
                     </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-list"></i>
-                        <span>Listas</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-users"></i>
-                        <span>Comunidades</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-briefcase"></i>
-                        <span>Negocios</span>
-                    </a>
-                    <a href="#" class="more-menu-item">
-                        <i class="fas fa-bullhorn"></i>
-                        <span>Anuncios</span>
-                    </a>
                     <div class="more-menu-divider"></div>
                     <a href="configuracion.html" class="more-menu-item">
                         <i class="fas fa-cog"></i>
                         <span>Configuracion</span>
                     </a>
-                    <a href="#" class="more-menu-item" data-action="logout">
+                    <button type="button" class="more-menu-item" data-action="logout">
                         <i class="fas fa-sign-out-alt"></i>
                         <span>Cerrar Sesion</span>
-                    </a>
+                    </button>
                 </div>
                 </div>
             </nav>
@@ -2148,7 +2132,7 @@
                         <div class="sidebar-hub-card-value" id="sidebarMiningTier">Bronce</div>
                         <div class="sidebar-hub-card-label">Tier actual</div>
                         <div class="sidebar-hub-card-meta" id="sidebarMiningStreak">0 dias de racha</div>
-                        <a href="#" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</a>
+                        <button type="button" class="sidebar-hub-card-btn" onclick="window.LaTandaPopup && window.LaTandaPopup.showInfo('Mineria proximamente')">Minar ahora</button>
                     </div>
                 </div>
 
@@ -2285,14 +2269,14 @@
             <div class="mobile-drawer-divider"></div>
             <div class="mobile-drawer-section-label">Herramientas</div>
 
-            <a href="#" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
+            <button type="button" class="mobile-drawer-item mia-trigger" data-action="drawer-mia">
                 <i class="fas fa-robot" style="color:#00FFFF;"></i>
                 <span>MIA Assistant</span>
-            </a>
-            <a href="#" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
+            </button>
+            <button type="button" class="mobile-drawer-item" onclick="MobileDrawer.close(); typeof openLotteryModal === 'function' && openLotteryModal() || window.LaTandaPopup && window.LaTandaPopup.showInfo('Predictor disponible pronto')">
                 <i class="fas fa-magic" style="color:#ffd700;"></i>
                 <span>Predictor Loteria</span>
-            </a>
+            </button>
             <a href="/lottery-predictor.html" class="mobile-drawer-item">
                 <i class="fas fa-ticket-alt"></i>
                 <span>Loteria</span>

--- a/trading.html
+++ b/trading.html
@@ -18,12 +18,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Trading | La Tanda Web3 Exchange</title>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"></noscript>
     <style>
         /* ================================

--- a/web3-dashboard.css
+++ b/web3-dashboard.css
@@ -553,6 +553,15 @@ body {
     font-size: 13px;
 }
 
+button.profile-menu-item {
+    width: 100%;
+    background: none;
+    border: 0;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+}
+
 .profile-menu-item:hover {
     background: rgba(0, 255, 255, 0.05);
     color: var(--accent-primary);
@@ -592,10 +601,6 @@ body {
     position: relative;
 }
 
-.theme-toggle input[type="checkbox"] {
-    display: none;
-}
-
 .toggle-slider {
     display: block;
     width: 32px;
@@ -619,11 +624,11 @@ body {
     transition: var(--transition-normal);
 }
 
-.theme-toggle input[type="checkbox"]:checked + .toggle-slider {
+.theme-toggle:not(.is-light) .toggle-slider {
     background: var(--accent-primary);
 }
 
-.theme-toggle input[type="checkbox"]:checked + .toggle-slider:before {
+.theme-toggle:not(.is-light) .toggle-slider:before {
     transform: translateX(14px);
     background: var(--bg-primary);
 }

--- a/web3-dashboard.html
+++ b/web3-dashboard.html
@@ -27,10 +27,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <!-- Optimized Google Fonts loading -->
-    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap"></noscript>
     <!-- Critical CSS: Font Awesome with async loading -->
-    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel=stylesheet">
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" as="style" crossorigin="anonymous" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous"></noscript>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0" />
     <!-- Custom chart implementation - no external dependencies needed -->
@@ -173,45 +173,44 @@
                             </div>
                             
                             <div class="profile-menu-items">
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openProfile()">
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openProfile()">
                                     <i class="fas fa-user"></i>
                                     <span>My Profile</span>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openWalletDetails()">
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openWalletDetails()">
                                     <i class="fas fa-wallet"></i>
                                     <span>Wallet Details</span>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openTransactionHistory()">
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openTransactionHistory()">
                                     <i class="fas fa-history"></i>
                                     <span>Transaction History</span>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openSettings()">
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openSettings()">
                                     <i class="fas fa-cog"></i>
                                     <span>Settings</span>
-                                </a>
+                                </button>
                                 <div class="profile-menu-divider"></div>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.toggleTheme()">
+                                <button type="button" class="profile-menu-item" onclick="dashboard.toggleTheme()">
                                     <i class="fas fa-moon" id="themeToggleIcon"></i>
                                     <span>Dark Mode</span>
-                                    <div class="theme-toggle">
-                                        <input type="checkbox" id="themeCheckbox" checked>
-                                        <label for="themeCheckbox" class="toggle-slider"></label>
-                                    </div>
-                                </a>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openLanguageSelector()">
+                                    <span class="theme-toggle" id="themeToggle" aria-hidden="true">
+                                        <span class="toggle-slider"></span>
+                                    </span>
+                                </button>
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openLanguageSelector()">
                                     <i class="fas fa-globe"></i>
                                     <span>Language</span>
                                     <span class="language-current">EN</span>
-                                </a>
+                                </button>
                                 <div class="profile-menu-divider"></div>
-                                <a href="#" class="profile-menu-item" onclick="dashboard.openSupport()">
+                                <button type="button" class="profile-menu-item" onclick="dashboard.openSupport()">
                                     <i class="fas fa-question-circle"></i>
                                     <span>Help & Support</span>
-                                </a>
-                                <a href="#" class="profile-menu-item disconnect" onclick="laTandaEcosystem?.handleWalletConnect()" id="disconnectWalletBtn" style="display: none;">
+                                </button>
+                                <button type="button" class="profile-menu-item disconnect" onclick="laTandaEcosystem?.handleWalletConnect()" id="disconnectWalletBtn" style="display: none;">
                                     <i class="fas fa-sign-out-alt"></i>
                                     <span>Disconnect Wallet</span>
-                                </a>
+                                </button>
                             </div>
                         </div>
                     </div>
@@ -4024,18 +4023,20 @@
                     
                     // Theme toggle
                     toggleTheme: function() {
-                        const checkbox = document.getElementById('themeCheckbox');
                         const icon = document.getElementById('themeToggleIcon');
-                        const isDark = checkbox.checked;
+                        const toggle = document.getElementById('themeToggle');
+                        const isDark = !toggle || !toggle.classList.contains('is-light');
                         
                         if (isDark) {
                             // Switch to light mode
                             icon.className = 'fas fa-sun';
+                            if (toggle) toggle.classList.add('is-light');
                             document.body.style.filter = 'brightness(1.1) contrast(0.9)';
                             laTandaEcosystem.showNotification('☀️ Switched to Light Mode');
                         } else {
                             // Switch to dark mode
                             icon.className = 'fas fa-moon';
+                            if (toggle) toggle.classList.remove('is-light');
                             document.body.style.filter = '';
                             laTandaEcosystem.showNotification('🌙 Switched to Dark Mode');
                         }


### PR DESCRIPTION
Fixes #155

## Summary
- Audited all 55 root `.html` files for placeholder links.
- Removed placeholder-only menu entries that had no backend route.
- Converted action-only triggers from `a href="#"` / `javascript:void(0)` into `button type="button"` while keeping normal navigation as real links.
- Fixed one dead admin redirect from `/admin-panel.html` to `/admin-panel-v2.html`.
- Fixed preload `onload` handlers using `this.rel='stylesheet'` so those pages do not throw console errors.

## Bounty Issue
Closes #155

## Codebase Verification
- Root HTML files at repo root: 55.
- Five examples: `index.html`, `auth-enhanced.html`, `home-dashboard.html`, `lottery-predictor.html`, `web3-dashboard.html`.
- Click actions should use `button`; navigational links remain `a` elements.

## Changes Made
- Replaced placeholder action links with buttons in menus, drawers, wallet/profile controls, and CTA/action UI.
- Removed non-functional placeholder-only menu/view-more links where no destination existed.
- Replaced the auth terms placeholder with `terms-of-service.html`.
- Updated generated markup for payment verification, tx copy, mentions, and hashtags to avoid `href="#"`.

## Verification
- Root HTML audit: `rootHtmlCount: 55`, `placeholders: 0`, `brokenHtmlLinks: 0`, `tagCountMismatches: 0`.
- `git diff --check`
- Inline script syntax check: 63 inline scripts checked, 3 non-JS/module scripts skipped, 0 failures.
- Browser smoke check on representative pages: placeholder link count 0 and console error count 0. Some pages still wait on external assets during full load, but DOM content was readable and no runtime errors were reported.

## Checklist
- [x] I tested my changes locally in the browser
- [x] My code modifies existing files
- [x] UI text remains in Spanish, code remains in English
- [x] No hardcoded credentials or secrets
- [ ] LTD payment address: can provide if required by maintainer
