### PR TITLE
docs: improve README developer onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,220 +1,244 @@
 # La Tanda — Web3 Ecosystem of Honduras
 
 > **Not an app. An ecosystem.**
-> Red social + tandas digitales + marketplace + minería + blockchain propia.
+> Social network + digital tandas + marketplace + mining + sovereign chain.
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 [![Chain](https://img.shields.io/badge/chain-latanda--testnet--1-00d4ff)](https://latanda.online/chain/)
-[![Supply](https://img.shields.io/badge/supply-200M%20LTD%20fijo-ffd700)](https://latanda.online/whitepaper.html)
+[![Supply](https://img.shields.io/badge/supply-200M%20LTD%20fixed-ffd700)](https://latanda.online/whitepaper.html)
 [![Inflation](https://img.shields.io/badge/inflation-0%25-22c55e)](https://latanda.online/whitepaper.html)
 [![Mainnet](https://img.shields.io/badge/mainnet-Q1%202027-8b5cf6)](https://latanda.online/chain/)
 
-Este repositorio es el **mirror público** del frontend de La Tanda, el primer ecosistema Web3 soberano construido en Honduras para Latinoamérica.
+This repository is the **public mirror** of the La Tanda frontend, the first sovereign Web3 ecosystem built in Honduras for Latin America.
 
 ---
 
-## 🌐 Qué es La Tanda
+## 🌐 What is La Tanda?
 
-La Tanda es un **ecosistema Web3 con 7 capas integradas**, no una simple app de tandas. Las tandas (grupos de ahorro rotativo ROSCA) son UNA de las 7 capas. Piénsalo como Amazon al e-commerce: mucho más que una caja de cartón.
+La Tanda is a **Web3 ecosystem with 7 integrated layers**, not a simple rotating-savings app. Tandas (ROSCA savings groups) are one of those layers. Think of it like Amazon compared with a single cardboard box: the box is useful, but the ecosystem is much larger.
 
-### Las 7 capas del ecosistema
+### The 7 ecosystem layers
 
-| # | Capa | Qué hace |
+| # | Layer | What it does |
 |---|---|---|
-| 1 | 💬 **Red Social** | Feed, stories, comentarios, reacciones. Tu tiempo genera reputación on-chain. |
-| 2 | 🔄 **Tandas Digitales** | Grupos de ahorro rotativo 0% comisión, score on-chain, préstamos integrados |
-| 3 | 🛍️ **Marketplace Web3** | Productos, servicios, bookings. Seller Score on-chain. Pagos en lempiras o LTD |
-| 4 | ⛏️ **Minería de LTD** | 5 tiers (1-12 LTD/día), cap 500 LTD/día global, gana por actividad real |
-| 5 | ⭐ **Reputación On-Chain** | Score financiero unificado 300-850, portable entre capas, anclado en blockchain |
-| 6 | 🔗 **La Tanda Chain** | Blockchain soberana Cosmos SDK + CometBFT, 200M LTD fijo, 0% inflación |
-| 7 | 🤖 **MIA AI** | Asistente financiero con 16 capacidades (Groq Llama 3.3 70B) |
+| 1 | 💬 **Social Network** | Feed, stories, comments, and reactions. Time spent in the ecosystem builds on-chain reputation. |
+| 2 | 🔄 **Digital Tandas** | 0% commission rotating savings groups, on-chain scoring, and integrated loans. |
+| 3 | 🛍️ **Web3 Marketplace** | Products, services, and bookings. Seller Score on-chain. Payments in lempiras or LTD. |
+| 4 | ⛏️ **LTD Mining** | 5 tiers (1-12 LTD/day), 500 LTD/day global cap, rewards earned through real activity. |
+| 5 | ⭐ **On-Chain Reputation** | Unified 300-850 financial score, portable across layers and anchored on-chain. |
+| 6 | 🔗 **La Tanda Chain** | Sovereign Cosmos SDK + CometBFT blockchain, fixed 200M LTD supply, 0% inflation. |
+| 7 | 🤖 **MIA AI** | Financial assistant with 16 capabilities, powered by Groq Llama 3.3 70B. |
 
 ---
 
-## 📊 Estado actual (live en testnet)
+## 📊 Current status (live on testnet)
 
-| Métrica | Valor actual |
+| Metric | Current value |
 |---|---|
-| **Usuarios activos mensuales** | 15,000+ |
-| **Tandas activas** | 300+ |
-| **Validadores de chain** | 13+ |
-| **API endpoints en producción** | 160+ |
-| **Algoritmos productivos** | 14 (fraud, ranking, credit, salud, etc.) |
-| **Propuestas de gobernanza pasadas** | 2 (GOV-001, GOV-002) |
-| **Uptime testnet desde Q1 2026** | 100% (sin incidentes de consenso) |
+| **Monthly active users** | 15,000+ |
+| **Active tandas** | 300+ |
+| **Chain validators** | 13+ |
+| **Production API endpoints** | 160+ |
+| **Production algorithms** | 14 (fraud, ranking, credit, health, and more) |
+| **Passed governance proposals** | 2 (GOV-001, GOV-002) |
+| **Testnet uptime since Q1 2026** | 100% (no consensus incidents) |
 
-Toda métrica es verificable contra datos on-chain o el dev portal público.
+All metrics are verifiable against on-chain data or the public developer portal.
 
 ---
 
-## 💎 Tokenomics (200M LTD fijo)
+## 💎 Tokenomics (fixed 200M LTD)
 
-**Modelo**: Supply fijo + Treasury pre-acuñado (similar a THORChain), **cero inflación real**.
+**Model:** fixed supply + pre-minted treasury, similar to THORChain, with **zero real inflation**.
 
-### Distribución (10 pools)
+### Distribution (10 pools)
 
-| Pool | % | Amount | Uso |
-|---|---|---|---|
-| Comunidad y Minería | 30% | 60M LTD | Recompensas usuarios, Incentivized Testnet |
-| Staking y Validadores | 20% | 40M LTD | Rewards pre-acuñados (APY 15-25%, ~8 años) |
-| Fondo de Desarrollo | 12% | 24M LTD | 6 meses cliff + 3 años linear |
-| Equipo y Fundadores | 12% | 24M LTD | 1 año cliff + 2 años linear |
-| Marketing y Alianzas | 6% | 12M LTD | Trimestral por hitos |
-| Seed Round | 5% | 10M LTD | $0.02/LTD, 6mo cliff + 18mo linear |
-| Strategic / Private | 5% | 10M LTD | $0.03/LTD, 3mo cliff + 12mo linear |
-| Liquidez Inicial TGE | 5% | 10M LTD | DEX pools + listings |
-| Bug Bounties y Grants | 3% | 6M LTD | Via governance |
-| Fondo de Seguro | 2% | 4M LTD | Emergency governance vote |
+| Pool | % | Amount | Use |
+|---|---:|---:|---|
+| Community and Mining | 30% | 60M LTD | User rewards and Incentivized Testnet |
+| Staking and Validators | 20% | 40M LTD | Pre-minted rewards (15-25% APY, ~8 years) |
+| Development Fund | 12% | 24M LTD | 6-month cliff + 3-year linear vesting |
+| Team and Founders | 12% | 24M LTD | 1-year cliff + 2-year linear vesting |
+| Marketing and Partnerships | 6% | 12M LTD | Quarterly milestone releases |
+| Seed Round | 5% | 10M LTD | $0.02/LTD, 6-month cliff + 18-month linear vesting |
+| Strategic / Private | 5% | 10M LTD | $0.03/LTD, 3-month cliff + 12-month linear vesting |
+| Initial TGE Liquidity | 5% | 10M LTD | DEX pools and listings |
+| Bug Bounties and Grants | 3% | 6M LTD | Via governance |
+| Insurance Fund | 2% | 4M LTD | Emergency governance vote |
 | **TOTAL** | **100%** | **200M LTD** | |
 
-**Post-Staking-Pool sustainability** (post año 8): 6 fuentes redundantes incluyendo **marketplace commission routing (0.5% GMV → validadores)** — un revenue stream único vs cadenas pure store-of-value.
+**Post-staking-pool sustainability** after year 8 uses six redundant sources, including **marketplace commission routing (0.5% GMV → validators)**, a revenue stream that differentiates La Tanda from pure store-of-value chains.
 
-Tokenomics completa: [Whitepaper v2.0](https://latanda.online/whitepaper.html) · [Página interactiva](https://latanda.online/ltd-token-economics.html)
+Full tokenomics: [Whitepaper v2.0](https://latanda.online/whitepaper.html) · [Interactive tokenomics page](https://latanda.online/ltd-token-economics.html)
 
 ---
 
 ## 🔗 La Tanda Chain
 
-Blockchain soberana construida con **Cosmos SDK + CometBFT**, específicamente diseñada para fintech comunitaria en Latinoamérica.
+La Tanda Chain is a sovereign blockchain built with **Cosmos SDK + CometBFT**, designed specifically for community fintech in Latin America.
 
-- **Chain ID (testnet)**: `latanda-testnet-1`
-- **Token**: LTD (denom `ultd`, 1 LTD = 1,000,000 ultd)
-- **Address prefix**: `ltd`
-- **Block time**: ~5 segundos
-- **Consensus**: CometBFT (BFT, Delegated Proof of Stake)
-- **Validators activos**: 13+ (genesis, PRO Delegators, drops, UTSA/lesnik, OwlStake, StakerHouse, ANODE.TEAM, AlxVoy, VALIDARIOS, narkosha, oleg1, +community)
-- **Governance**: activa, 2 props pasadas
-- **Mainnet**: Q1 2027 planificado
-- **Explorer (community)**: https://exp.utsa.tech/latanda/staking
+- **Chain ID (testnet):** `latanda-testnet-1`
+- **Token:** LTD (denom `ultd`, 1 LTD = 1,000,000 ultd)
+- **Address prefix:** `ltd`
+- **Block time:** ~5 seconds
+- **Consensus:** CometBFT (BFT, Delegated Proof of Stake)
+- **Active validators:** 13+ (genesis, PRO Delegators, drops, UTSA/lesnik, OwlStake, StakerHouse, ANODE.TEAM, AlxVoy, VALIDARIOS, narkosha, oleg1, and community validators)
+- **Governance:** active, 2 passed proposals
+- **Mainnet:** planned for Q1 2027
+- **Community explorer:** https://exp.utsa.tech/latanda/staking
 
 ### Incentivized Testnet Program
 
-Reservados ~100K LTD para validadores que se suman antes del mainnet:
+About 100K LTD is reserved for validators who join before mainnet:
 
-| Tier | Slots | Reward al genesis |
-|---|---|---|
-| Infra Partner | 5 (4 ocupados) | 5,000 LTD |
+| Tier | Slots | Genesis reward |
+|---|---:|---:|
+| Infra Partner | 5 (4 occupied) | 5,000 LTD |
 | Validator | 10 | 2,000 LTD |
 | Full Node | 20 | 500 LTD |
-| Bug Reporter | abierto | 100-1,000 LTD |
+| Bug Reporter | Open | 100-1,000 LTD |
 
-**Cómo sumarte**: [Node Operator Guide](./la-tanda-chain-node-guide.md) (si está en este repo) o [latanda.online/chain](https://latanda.online/chain/)
+**How to join:** read the [Node Operator Guide](https://latanda.online/la-tanda-chain-node-guide.md) or visit [latanda.online/chain](https://latanda.online/chain/).
 
 ---
 
 ## 🚀 Quick Start
 
-### Para usuarios (no technical)
-1. Ve a [latanda.online](https://latanda.online)
-2. Crea tu cuenta (email o Google Sign-In)
-3. Únete a una tanda, publica en el feed, mina LTD, explora el marketplace
+### For users
+1. Go to [latanda.online](https://latanda.online).
+2. Create an account with email or Google Sign-In.
+3. Join a tanda, publish in the feed, mine LTD, and explore the marketplace.
 
-### Para desarrolladores (integrar con La Tanda API)
-1. Documentación API: https://latanda.online/docs
-2. Dev portal: https://latanda.online/dev-dashboard.html
-3. Autenticación: JWT via `/api/auth/login`
-4. 160+ endpoints productivos
+### For developers integrating with the La Tanda API
+1. API documentation: https://latanda.online/docs
+2. Developer portal: https://latanda.online/dev-dashboard.html
+3. Authentication: JWT via `/api/auth/login`
+4. 160+ production endpoints are available.
 
-### Para validadores (correr un nodo)
-1. Lee la guía: [la-tanda-chain-node-guide.md](https://latanda.online/la-tanda-chain-node-guide.md)
-2. Instalación one-line: `wget -q https://latanda.online/chain/node-setup.sh -O node-setup.sh && chmod +x node-setup.sh && ./node-setup.sh`
-3. Chain page con seeds: https://latanda.online/chain/
-4. Únete al Incentivized Testnet Program enviando 10 LTD testnet + create-validator tx
+### For validators running a node
+1. Read the [Node Operator Guide](https://latanda.online/la-tanda-chain-node-guide.md).
+2. Install with one command: `wget -q https://latanda.online/chain/node-setup.sh -O node-setup.sh && chmod +x node-setup.sh && ./node-setup.sh`
+3. Chain page with seeds: https://latanda.online/chain/
+4. Join the Incentivized Testnet Program by sending 10 testnet LTD and creating a validator transaction.
 
 ---
 
-## 📂 Estructura del repositorio
+## 🛠️ Development Setup
 
+This repository is a static frontend mirror. You can serve it locally without a build step:
+
+```bash
+npx serve .
 ```
+
+Then open the local URL printed by `serve` in your browser, usually `http://localhost:3000`.
+
+Recommended development checks:
+
+1. Confirm the page you changed loads locally.
+2. Check the browser console for JavaScript errors.
+3. Verify any public links you touched, especially [Swagger UI](https://latanda.online/docs), [Dev Portal](https://latanda.online/dev-dashboard.html), and [Chain Explorer](https://exp.utsa.tech/latanda/staking).
+
+---
+
+## 📂 Project Structure
+
+```text
 la-tanda-web/
-├── *.html                    # Páginas del ecosistema (60+ archivos)
-├── css/                      # Estilos (design-tokens, components, modules)
-├── js/                       # JavaScript (components-loader, hub, utilities)
-├── assets/                   # Imágenes, logos, favicons
-├── chain/                    # Recursos de La Tanda Chain (node-setup.sh, genesis.json)
-├── docs/                     # OpenAPI spec + Swagger UI
-├── .github/                  # Bounty templates, PR gatekeeper
-└── api-*.js                  # API adapters y proxies
+├── *.html                    # Ecosystem pages and public entry points
+├── css/                      # Stylesheets, design tokens, components, and modules
+├── js/                       # Shared JavaScript components, loaders, hub code, and utilities
+├── assets/                   # Images, generated assets, logos, favicons, and bundled chunks
+├── chain/                    # La Tanda Chain resources such as node setup and genesis files
+├── docs                      # Swagger UI / API documentation entry point
+├── .github/                  # Issue templates, PR template, and repository automation
+└── api-*.js                  # API adapters, endpoint config, handlers, and proxy implementations
 ```
 
-**Páginas principales alineadas al framework**:
-- `index.html` — Landing con hero cósmico 3D + tokenomics donut + personas cards
-- `whitepaper.html` — Whitepaper v2.0 con 10 pools + 6 fuentes sustainability
-- `ltd-token-economics.html` — Tokenomics interactiva con datos live del chain
-- `governance.html` — Hub de gobernanza on-chain con Keplr wallet
-- `mia.html` — MIA AI (7ma capa del ecosistema)
-- `chain/index.html` — Chain landing con stats live
+Key pages aligned with the ecosystem framework:
+
+- `index.html` — landing page with cosmic 3D hero, tokenomics donut, and persona cards.
+- `whitepaper.html` — Whitepaper v2.0 with 10 pools and 6 sustainability sources.
+- `ltd-token-economics.html` — interactive tokenomics page with live chain data.
+- `governance.html` — on-chain governance hub with Keplr wallet support.
+- `mia.html` — MIA AI, the seventh ecosystem layer.
+- `chain/index.html` — chain landing page with live stats.
+- `marketplace-social.html` — marketplace social experience; its root-level script is `marketplace-social.js`.
+
+The main API implementation file is `api-proxy-enhanced.js`. Supporting API files include `api-endpoints-config.js`, `api-adapter.js`, `api-proxy.js`, and `api-handlers-complete.js`.
 
 ---
 
-## 🤝 Cómo contribuir
+## 🤝 Contributing
 
-La Tanda tiene un **sistema de bounties de 3 tiers** en GitHub Issues:
+La Tanda uses a **3-tier GitHub bounty system**:
 
-| Tier | Quién puede | Reward |
-|---|---|---|
-| **Tier 0** | Cualquiera | 10-50 LTD |
-| **Tier 1** | 1+ merge previo | 50-150 LTD |
-| **Tier 2** | 2+ merges previos | 150-500 LTD |
+| Tier | Who can claim | Reward |
+|---|---|---:|
+| **Tier 0** | Anyone | 10-50 LTD |
+| **Tier 1** | 1+ previous merge | 50-150 LTD |
+| **Tier 2** | 2+ previous merges | 150-500 LTD |
 
-- Cada bounty requiere responder una pregunta de verificación del código (requiere leer la fuente real)
-- PR Gatekeeper automático rechaza: PRs sin asignación, cuentas <30 días, usuarios en ban list
-- Labels: `tier-0`, `tier-1`, `tier-2`
+- Each bounty includes a codebase verification question that requires reading the real source.
+- The automated PR gatekeeper rejects unassigned PRs, accounts younger than 30 days, and users on the ban list.
+- Labels: `tier-0`, `tier-1`, `tier-2`.
 
-**Antes de abrir PR**:
-1. Lee `CONTRIBUTING.md` (si existe) + `.github/ban-list.txt`
-2. Responde la pregunta de verificación del bounty
-3. Firma commits con tu email verificado en GitHub
-4. Un PR = un bounty
+Before opening a PR:
+
+1. Read the repository rules and `.github/ban-list.txt` if present.
+2. Answer the bounty verification question.
+3. Sign commits with your verified GitHub email.
+4. Keep each PR focused on one bounty.
 
 ---
 
-## 📚 Recursos
+## 📚 Resources
 
-### Documentación pública
+### Public documentation
 - 🌐 Website: [latanda.online](https://latanda.online)
 - 📜 Whitepaper v2.0: [latanda.online/whitepaper.html](https://latanda.online/whitepaper.html)
 - 💰 Tokenomics: [latanda.online/ltd-token-economics.html](https://latanda.online/ltd-token-economics.html)
 - 🏛️ Governance: [latanda.online/governance.html](https://latanda.online/governance.html)
 - 💻 Dev Portal: [latanda.online/dev-dashboard.html](https://latanda.online/dev-dashboard.html)
-- 📖 API Docs: [latanda.online/docs](https://latanda.online/docs)
+- 📖 API Docs / Swagger UI: [latanda.online/docs](https://latanda.online/docs)
 - 🔗 Chain: [latanda.online/chain](https://latanda.online/chain/)
+- 🔎 Chain Explorer: [exp.utsa.tech/latanda/staking](https://exp.utsa.tech/latanda/staking)
 
-### Comunidad
+### Community
 - 💬 Discord: [discord.gg/Ve9M2ZSYC2](https://discord.gg/Ve9M2ZSYC2)
 - 📢 Telegram: [t.me/latandahn](https://t.me/latandahn)
 - 🐦 Twitter: [@TandaWeb3](https://twitter.com/TandaWeb3)
 - 📰 Cosmos Forum: [Thread #16709](https://forum.cosmos.network/t/la-tanda-chain-incentivized-testnet-live-validators-node-operators-welcome-cosmos-sdk-v0-53-6/16709)
-- 🟣 Reddit (own sub): [r/LaTandaChain](https://reddit.com/r/LaTandaChain)
+- 🟣 Reddit: [r/LaTandaChain](https://reddit.com/r/LaTandaChain)
 
 ---
 
-## 📜 Licencia
+## 📜 License
 
-MIT License — see [LICENSE](./LICENSE)
+MIT License — see [LICENSE](./LICENSE).
 
-Código abierto, uso libre con atribución. Las marcas "La Tanda" y "La Tanda Chain" son propiedad de Ray-Banks LLC.
+The code is open source and free to use with attribution. The "La Tanda" and "La Tanda Chain" brands are property of Ray-Banks LLC.
 
 ---
 
 ## ⚖️ Legal
 
-La Tanda es operada por **Ray-Banks LLC**. Más información en [raybanks.org](https://raybanks.org).
+La Tanda is operated by **Ray-Banks LLC**. More information is available at [raybanks.org](https://raybanks.org).
 
-Este repositorio es un mirror público del frontend. El código está liberado para transparencia y contribuciones comunitarias. No constituye oferta de valores ni asesoramiento financiero.
+This repository is a public mirror of the frontend. The code is released for transparency and community contributions. It is not a securities offering or financial advice.
 
 ---
 
-## 🚫 Reglas importantes
+## 🚫 Important Rules
 
-- **NUNCA** commitees `.env` o credenciales (ver `.env.example`)
-- **NUNCA** uses `rsync --delete` con este repo
-- **NUNCA** modifiques `api-proxy-enhanced.js` sin coordinar con el equipo
-- Ban list pública: `.github/ban-list.txt` (no aceptamos PRs de cuentas listadas)
+- **NEVER** commit `.env` files or credentials; see `.env.example`.
+- **NEVER** use `rsync --delete` with this repository.
+- **NEVER** modify `api-proxy-enhanced.js` without coordinating with the team.
+- Public ban list: `.github/ban-list.txt`, when present.
 
 ---
 
 <p align="center">
-<strong>Construyendo el Web3 de Latinoamérica, un tanda a la vez.</strong><br>
+<strong>Building the Web3 of Latin America, one tanda at a time.</strong><br>
 🇭🇳 Honduras → 🌎 LatAm → 🌍 Global
 </p>


### PR DESCRIPTION
## Description
Improves the README developer onboarding documentation for the Tier 0 documentation bounty.

## Bounty Issue
Closes #50

## Codebase Verification
`marketplace-social.js` exists in both locations, but the active marketplace page loads the root-level `marketplace-social.js` from `marketplace-social.html`. The main API implementation file is `api-proxy-enhanced.js`.

## Changes Made
- Added a clear Development Setup section for serving the static frontend with `npx serve .`.
- Reworked the Project Structure section in English with the actual repository directories and API files.
- Verified public resource links for Swagger UI/API docs, Dev Portal, and Chain Explorer.
- Kept the change scoped to `README.md` only.

## Checklist

- [ ] I am **assigned** to the bounty issue (not just commenting)
- [x] I read the repository rules and `.github/ban-list.txt` when present
- [x] I tested documentation formatting locally with `git diff --check`
- [x] My code modifies existing files (not new standalone scripts)
- [x] API endpoints verified against [Swagger UI](https://latanda.online/docs)
- [x] No hardcoded credentials or secrets

## Screenshots
Documentation-only change.

## LTD Payment Address
`ltd1...`
