### PR TITLE
docs(readme): add development setup and project structure (fixes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,47 @@ Reservados ~100K LTD para validadores que se suman antes del mainnet:
 
 ---
 
+## Development Setup
+
+English onboarding for developers working on this static frontend mirror:
+
+```bash
+git clone https://github.com/INDIGOAZUL/la-tanda-web.git
+cd la-tanda-web
+npx serve .
+```
+
+Then open the local URL printed by `serve` (typically `http://localhost:3000`).
+
+Useful entry points while developing:
+
+- [Swagger UI / OpenAPI docs](https://latanda.online/docs)
+- [Dev Portal](https://latanda.online/dev-dashboard.html)
+- [Chain Explorer / chain landing](https://latanda.online/chain/)
+
+JWT auth for API calls uses `/api/auth/login` against the production API base documented in the Dev Portal.
+
+---
+
+## Project Structure
+
+Key directories in this repository:
+
+| Path | Purpose |
+|---|---|
+| `*.html` | Static ecosystem pages (landing, marketplace, governance, chain, docs shell) |
+| `css/` | Shared styles, design tokens, and module CSS |
+| `js/` | Frontend modules (component loader, hub connectors, page helpers) |
+| `assets/` | Built/bundled JS chunks, images, and favicons |
+| `chain/` | Chain resources such as genesis metadata and node setup helpers |
+| `docs/` | OpenAPI spec and Swagger UI assets |
+| `api-proxy.js` | Local-development API proxy/simulator used by static pages |
+| `.github/` | Issue/PR templates, bounty labels, automation |
+
+Main marketplace social page wiring: `marketplace-social.html` loads `marketplace-social.js` from the repository root.
+
+---
+
 ## 📂 Estructura del repositorio
 
 ```


### PR DESCRIPTION
## Summary

Adds English developer onboarding to `README.md` for bounty #50:

- **Development Setup** — clone repo and serve locally with `npx serve .`
- **Project Structure** — key directories and where marketplace/API files live
- Verified links to Swagger UI, Dev Portal, and Chain landing

## Codebase verification

- `marketplace-social.js` is loaded from the **HTML root** by `marketplace-social.html` (`<script src="marketplace-social.js?...">`). A copy also exists under `js/`, but the page uses the root file.
- Main local API entry file: **`api-proxy.js`**

## Wallet

`Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

Fixes #50
