### PR TITLE
fix: repair root HTML links

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -726,7 +726,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/bridge.html
+++ b/bridge.html
@@ -697,7 +697,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/commission-system.html
+++ b/commission-system.html
@@ -1186,7 +1186,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/configuracion.html
+++ b/configuracion.html
@@ -1581,7 +1581,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/creator-hub.html
+++ b/creator-hub.html
@@ -2415,7 +2415,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/dev-dashboard.html
+++ b/dev-dashboard.html
@@ -515,7 +515,7 @@
                 <a href="#bounties">Bounties</a>
                 <a href="#faq">FAQ</a>
                 <a href="#patterns">Patrones</a>
-                <a href="/docs" target="_blank" rel="noopener noreferrer">Swagger UI</a>
+                <a href="/dev-dashboard.html#endpoints">API Reference</a>
                 <a href="https://github.com/INDIGOAZUL/la-tanda-web" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> GitHub</a>
             </nav>
         </div>
@@ -525,7 +525,7 @@
         <h1>La Tanda Developer API</h1>
         <p>Integra servicios financieros colaborativos en tu aplicación. API RESTful con autenticación JWT.</p>
         <div class="hero-buttons">
-            <a href="/docs" class="btn btn-primary" target="_blank" rel="noopener noreferrer">
+            <a href="/dev-dashboard.html#endpoints" class="btn btn-primary">
                 <i class="fas fa-book"></i> Documentación Completa
             </a>
             <a href="#quick-start" class="btn btn-secondary">
@@ -611,7 +611,7 @@
                         <a href="/postman-collection.json" download class="btn btn-secondary" style="justify-content: flex-start;">
                             <i class="fas fa-download"></i> Postman Collection
                         </a>
-                        <a href="/docs" target="_blank" rel="noopener noreferrer" class="btn btn-secondary" style="justify-content: flex-start;">
+                        <a href="/dev-dashboard.html#endpoints" class="btn btn-secondary" style="justify-content: flex-start;">
                             <i class="fas fa-book"></i> Swagger UI
                         </a>
                         <a href="https://github.com/INDIGOAZUL/la-tanda-web" target="_blank" rel="noopener noreferrer" class="btn btn-secondary" style="justify-content: flex-start;">
@@ -1075,7 +1075,7 @@ setInterval(() =&gt; {
                 </div>
             </div>
             <p style="margin-top: 1rem; color: var(--text-secondary);">
-                <i class="fas fa-info-circle"></i> Ver la <a href="/docs" target="_blank" rel="noopener noreferrer" style="color: var(--tanda-cyan);">documentación completa</a> para todos los endpoints disponibles.
+                <i class="fas fa-info-circle"></i> Ver la <a href="/dev-dashboard.html#endpoints" style="color: var(--tanda-cyan);">documentación completa</a> para todos los endpoints disponibles.
             </p>
         </section>
 
@@ -1672,7 +1672,7 @@ docs/swagger/openapi.json
                         <span style="color: #ef4444;">&#10007;</span> <code>error.message</code> al cliente → mensajes genericos en espanol
                     </div>
                     <div style="background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 8px; padding: 0.6rem 0.8rem; font-size: 0.82rem;">
-                        <span style="color: #ef4444;">&#10007;</span> URLs fabricadas → verificar en <a href="/docs" style="color: var(--tanda-cyan);">Swagger UI</a>
+                        <span style="color: #ef4444;">&#10007;</span> URLs fabricadas → verificar en <a href="/dev-dashboard.html#endpoints" style="color: var(--tanda-cyan);">Swagger UI</a>
                     </div>
                 </div>
             </div>
@@ -1743,7 +1743,7 @@ docs/swagger/openapi.json
     </main>
     
     <footer class="footer">
-        <p>© 2024-2026 La Tanda. <a href="index.html">Volver al inicio</a> | <a href="/docs" target="_blank" rel="noopener noreferrer">Swagger UI</a>
+        <p>© 2024-2026 La Tanda. <a href="index.html">Volver al inicio</a> | <a href="/dev-dashboard.html#endpoints">API Reference</a>
                 <a href="https://github.com/INDIGOAZUL/la-tanda-web" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i> GitHub</a></p>
     </footer>
     

--- a/explorar.html
+++ b/explorar.html
@@ -2394,7 +2394,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/gestionar.html
+++ b/gestionar.html
@@ -3890,7 +3890,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/governance.html
+++ b/governance.html
@@ -1834,7 +1834,7 @@ EOF
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/groups-advanced-system.html
+++ b/groups-advanced-system.html
@@ -1559,7 +1559,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/guardados.html
+++ b/guardados.html
@@ -2347,7 +2347,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/home-dashboard.html
+++ b/home-dashboard.html
@@ -1421,7 +1421,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/index.html
+++ b/index.html
@@ -1830,7 +1830,7 @@
                         <li><a href="kyc-registration.html">Verificación</a></li>
                         <li><a href="terms-of-service.html">Tarifas</a></li>
                         <li><a href="seguridad.html">Seguridad</a></li>
-                        <li><a href="/docs">API Docs</a></li>
+                        <li><a href="/dev-dashboard.html#endpoints">API Docs</a></li>
                     </ul>
                 </div>
                 

--- a/invest.html
+++ b/invest.html
@@ -947,8 +947,8 @@
                 <a href="mailto:invest@latanda.online?subject=Investment%20Inquiry%20-%20La%20Tanda" class="btn-primary">
                     <i class="fas fa-paper-plane"></i> invest@latanda.online
                 </a>
-                <a href="/docs/SAFT-La-Tanda-Template.md" class="btn-outline" target="_blank">
-                    <i class="fas fa-file-contract"></i> Download SAFT
+                <a href="mailto:invest@latanda.online?subject=SAFT%20template%20request" class="btn-outline">
+                    <i class="fas fa-file-contract"></i> Request SAFT
                 </a>
                 <a href="https://discord.gg/Ve9M2ZSYC2" class="btn-outline" target="_blank">
                     <i class="fab fa-discord"></i> Discord

--- a/invitaciones.html
+++ b/invitaciones.html
@@ -1118,7 +1118,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/kyc-registration.html
+++ b/kyc-registration.html
@@ -1743,7 +1743,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/lending.html
+++ b/lending.html
@@ -630,7 +630,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/lottery-predictor.html
+++ b/lottery-predictor.html
@@ -2449,7 +2449,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/lottery-stats.html
+++ b/lottery-stats.html
@@ -896,7 +896,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/ltd-token-economics.html
+++ b/ltd-token-economics.html
@@ -1189,7 +1189,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/mensajes.html
+++ b/mensajes.html
@@ -2338,7 +2338,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/mi-perfil.html
+++ b/mi-perfil.html
@@ -686,7 +686,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/mia.html
+++ b/mia.html
@@ -892,7 +892,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/mineria.html
+++ b/mineria.html
@@ -595,7 +595,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/my-tandas.html
+++ b/my-tandas.html
@@ -1386,7 +1386,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/my-wallet.html
+++ b/my-wallet.html
@@ -3005,7 +3005,7 @@ function patchWalletAPI() {
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/nft-memberships.html
+++ b/nft-memberships.html
@@ -1554,7 +1554,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/perfil.html
+++ b/perfil.html
@@ -394,7 +394,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/recompensas.html
+++ b/recompensas.html
@@ -372,7 +372,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/seguridad.html
+++ b/seguridad.html
@@ -1911,7 +1911,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/staking.html
+++ b/staking.html
@@ -1369,7 +1369,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/trabajo.html
+++ b/trabajo.html
@@ -2380,7 +2380,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/trading.html
+++ b/trading.html
@@ -1055,7 +1055,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>

--- a/web3-dashboard.html
+++ b/web3-dashboard.html
@@ -4110,7 +4110,7 @@
             <i class="fas fa-store"></i>
             <span>Mercado</span>
         </a>
-        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item" data-action="goto-mi-tienda">
+        <a href="/marketplace-social.html#mi-tienda" class="mobile-nav-item">
             <i class="fas fa-shopping-bag"></i>
             <span>Mi Tienda</span>
         </a>


### PR DESCRIPTION
Fixes #155

## Summary
- Replaced the remaining dead root-page `/docs` links with the existing `dev-dashboard.html#endpoints` API reference section.
- Replaced the missing `/docs/SAFT-La-Tanda-Template.md` download link with a mailto request CTA for the SAFT template.
- Removed `data-action="goto-mi-tienda"` from 31 real navigation anchors so delegated click actions remain reserved for `<button data-action>` controls.

## Codebase verification answer
- Root HTML files: 55
- Examples: `404.html`, `50x.html`, `admin-audit-logs-viewer.html`, `admin-kyc-review.html`, `admin-panel-v2.html`
- Click actions use `<button data-action>` with delegated handlers; navigation stays as `<a href>`.

## Verification
- `git diff --check`
- Python audit over root `*.html`:
  - `href="#"`: 0
  - `href="javascript:void(0)"`: 0
  - `data-action="goto-mi-tienda"`: 0
  - missing internal root links: 0
  - HTML parser errors: 0
