### PR TITLE
feat(ui): add dark and light theme toggle support

### DIFF
--- a/components/sidebar.html
+++ b/components/sidebar.html
@@ -202,6 +202,10 @@
             <i class="fas fa-cog nav-icon"></i>
             <span class="nav-text" data-i18n="home_dashboard.configuration">Configuración</span>
         </a>
+        <a href="#" class="nav-item" id="sidebarThemeToggleBtn" onclick="event.preventDefault(); toggleTheme();">
+            <i class="fas fa-moon nav-icon theme-toggle-icon"></i>
+            <span class="nav-text theme-toggle-text">Modo Claro</span>
+        </a>
     </nav>
 
     <!-- Logout Footer -->

--- a/css/design-tokens.css
+++ b/css/design-tokens.css
@@ -120,6 +120,44 @@
  --ds-sidebar-width: 275px;
  --ds-content-max: 800px;
  --ds-right-rail: 350px;
- 
- 
+}
+
+/* ============================================
+   LIGHT THEME OVERRIDES (Issue #84)
+   ============================================ */
+:root[data-theme="light"], html[data-theme="light"] {
+  --ds-bg-base: #f8fafc;
+  --ds-bg-surface: rgba(0, 0, 0, 0.03);
+  --ds-bg-surface-hover: rgba(0, 0, 0, 0.05);
+  --ds-bg-elevated: rgba(0, 0, 0, 0.04);
+  --ds-bg-overlay: rgba(15, 23, 42, 0.7);
+  --ds-bg-overlay-heavy: rgba(15, 23, 42, 0.85);
+  --ds-bg-input: rgba(0, 0, 0, 0.04);
+  --ds-bg-input-focus: rgba(0, 0, 0, 0.06);
+
+  --ds-text-primary: #0f172a;
+  --ds-text-secondary: #334155;
+  --ds-text-muted: #64748b;
+  --ds-text-faint: #94a3b8;
+
+  --ds-border: rgba(0, 0, 0, 0.08);
+  --ds-border-hover: rgba(0, 0, 0, 0.15);
+
+  --ds-cyan: #0284c7;
+  --ds-cyan-hover: #0369a1;
+  --ds-cyan-muted: rgba(2, 132, 199, 0.1);
+  --ds-cyan-border: rgba(2, 132, 199, 0.2);
+  --ds-cyan-glow: 0 0 15px rgba(2, 132, 199, 0.15);
+
+  /* Page-level overrides */
+  --bg-primary: #f8fafc;
+  --bg-secondary: #f1f5f9;
+  --bg-card: rgba(255, 255, 255, 0.85);
+  --text-primary: #0f172a;
+  --text-secondary: rgba(15, 23, 42, 0.7);
+  --border-card: rgba(0, 0, 0, 0.08);
+  --border-accent: rgba(2, 132, 199, 0.2);
+  --tanda-cyan: #0284c7;
+  --tanda-cyan-light: #38bdf8;
+  --tanda-cyan-dark: #0369a1;
 }

--- a/js/components-loader.js
+++ b/js/components-loader.js
@@ -1,5 +1,12 @@
+// Initialize theme immediately to prevent FOUC (Issue #84)
+(function(){
+  const savedTheme = localStorage.getItem("theme_preference") || "dark";
+  document.documentElement.setAttribute("data-theme", savedTheme);
+})();
+
 // Phase 0: Load helpers + iOS PWA prompt (i18n removed — platform uses Spanish)
 (function(){
+
   var scripts = [
     'js/helpers/locale-helpers.js?v=1.0',
     'js/helpers/fetch-retry.js?v=1.0',
@@ -58,6 +65,7 @@ LaTandaComponentLoader.loadMobileDrawer = async function() {
         +     '<div class="mobile-drawer-divider"></div>'
         +     '<a href="/mi-perfil.html" class="mobile-drawer-item"><i class="fas fa-cog"></i><span>Configuracion</span></a>'
         +     '<a href="/help-center.html" class="mobile-drawer-item"><i class="fas fa-question-circle"></i><span>Ayuda</span></a>'
+        +     '<a href="#" class="mobile-drawer-item" id="mobileThemeToggleBtn" onclick="event.preventDefault(); toggleTheme();"><i class="fas fa-moon mobile-theme-icon"></i><span>Modo Claro</span></a>'
         +   '</nav>'
         +   '<div class="mobile-drawer-divider"></div>'
         +   '<div class="mobile-drawer-section-label">Tu Resumen</div>'
@@ -201,4 +209,49 @@ document.addEventListener('DOMContentLoaded', function() {
     setTimeout(function() {
         LaTandaComponentLoader.loadMobileDrawer();
     }, 500);
+});
+
+// Theme Management Logic (Issue #84)
+window.toggleTheme = function() {
+    const currentTheme = document.documentElement.getAttribute("data-theme") || "dark";
+    const newTheme = currentTheme === "dark" ? "light" : "dark";
+    document.documentElement.setAttribute("data-theme", newTheme);
+    window._safeSetItem("theme_preference", newTheme);
+    window.updateThemeUI(newTheme);
+};
+
+window.updateThemeUI = function(theme) {
+    const isLight = theme === "light";
+    
+    // Update sidebar items
+    const sidebarBtns = document.querySelectorAll("#sidebarThemeToggleBtn");
+    sidebarBtns.forEach(btn => {
+        const textSpan = btn.querySelector(".theme-toggle-text");
+        const icon = btn.querySelector(".theme-toggle-icon");
+        if (textSpan) textSpan.textContent = isLight ? "Modo Oscuro" : "Modo Claro";
+        if (icon) {
+            icon.className = isLight ? "fas fa-moon nav-icon theme-toggle-icon" : "fas fa-sun nav-icon theme-toggle-icon";
+        }
+    });
+    
+    // Update mobile drawer items
+    const mobileBtns = document.querySelectorAll("#mobileThemeToggleBtn");
+    mobileBtns.forEach(btn => {
+        const textSpan = btn.querySelector("span");
+        const icon = btn.querySelector("i");
+        if (textSpan) textSpan.textContent = isLight ? "Modo Oscuro" : "Modo Claro";
+        if (icon) {
+            icon.className = isLight ? "fas fa-moon mobile-theme-icon" : "fas fa-sun mobile-theme-icon";
+        }
+    });
+};
+
+document.addEventListener("DOMContentLoaded", function() {
+    const savedTheme = window._safeGetItem("theme_preference") || "dark";
+    window.updateThemeUI(savedTheme);
+});
+
+document.addEventListener("sidebarLoaded", function() {
+    const savedTheme = window._safeGetItem("theme_preference") || "dark";
+    window.updateThemeUI(savedTheme);
 });


### PR DESCRIPTION
## Summary

Adds complete Dark and Light theme toggle support to the platform. Supports both desktop (sidebar) and mobile (bottom navigation drawer) views.

## Changes
- **Design Tokens**: Appends light theme CSS variable overrides to `css/design-tokens.css` covering all core variables (`--bg-primary`, `--text-primary`, `--border-card`, `--ds-bg-base`, etc.).
- **Desktop Sidebar**: Injects theme toggle link inside the Account (`CUENTA`) section of `components/sidebar.html`.
- **Mobile Drawer**: Injects theme toggle item inside the mobile drawer menu in `js/components-loader.js`.
- **Logic**: Integrates `toggleTheme()` and `updateThemeUI()` functions inside `js/components-loader.js` that reads/writes theme state from/to `localStorage` using the key `theme_preference`.
- **Immediate Initialization**: Implements a small script at the top of `js/components-loader.js` that applies the saved theme to `document.documentElement` immediately, preventing FOUC.

## Codebase Verification Answers
- **What is the value of `--bg-primary`?**
  It is `#0f172a`.
- **Which file sets the `body { background }` for hub pages?**
  It is set directly inside the inline `<style>` block of each individual HTML file (e.g. `home-dashboard.html`, `marketplace-social.html`, `gestionar.html`).

Closes #84